### PR TITLE
WebConnection(Wrapper): throw a more specific IOException from close() that does not include InterruptedException

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/WebConnection.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/WebConnection.java
@@ -34,4 +34,6 @@ public interface WebConnection extends AutoCloseable {
      */
     WebResponse getResponse(WebRequest request) throws IOException;
 
+    @Override
+    void close() throws IOException;
 }

--- a/src/main/java/com/gargoylesoftware/htmlunit/util/WebConnectionWrapper.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/util/WebConnectionWrapper.java
@@ -83,7 +83,7 @@ public class WebConnectionWrapper implements WebConnection {
      * The default behavior of this method is to return {@link WebConnection#close()} on the wrapped connection object.
      */
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         wrappedWebConnection_.close();
     }
 }


### PR DESCRIPTION
🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 
NOTE: THIS WILL BREAK COMPILATION FOR ALL USERS OF THE LIBRARY
THAT HAVE BEEN CATCHING THE MORE GENERIC EXCEPTION SO FAR.
🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥

I defined my own subclass of WebConnectionWrapper to wrap a WebConnection, and got the warning

```text
Warning:(91, 81) java: auto-closeable resource <anonymous com.gargoylesoftware.htmlunit.util.WebConnectionWrapper> has a member method close() that could throw InterruptedException
Error:java: warnings found and -Werror specified
```

AutoCloseable javadoc says 

```text
* <p>While this interface method is declared to throw {@code
* Exception}, implementers are <em>strongly</em> encouraged to
* declare concrete implementations of the {@code close} method to
* throw more specific exceptions, or to throw no exception at all
* if the close operation cannot fail.

* <p><em>Implementers of this interface are also strongly advised
* to not have the {@code close} method throw {@link
* InterruptedException}.</em>
```

Suggested solution is to throw the more specific exception `IOException`

- `@Override void close() throws IOException;` in WebConnectionWrapper
- `@Override void close() throws IOException;` in WebConnection
