### PR TITLE
Allow clearing multiple inputs

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlColorInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlColorInput.java
@@ -20,6 +20,7 @@ import java.awt.Color;
 import java.util.Map;
 
 import com.gargoylesoftware.htmlunit.SgmlPage;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Wrapper for the HTML element "input" where type is "color".
@@ -57,7 +58,7 @@ public class HtmlColorInput extends HtmlInput {
      */
     @Override
     public void setValueAttribute(final String newValue) {
-        if (hasFeature(JS_INPUT_SET_VALUE_MOVE_SELECTION_TO_START) || isValid(newValue)) {
+        if (hasFeature(JS_INPUT_SET_VALUE_MOVE_SELECTION_TO_START) || StringUtils.isEmpty(newValue) || isValid(newValue)) {
             super.setValueAttribute(newValue);
         }
     }

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateInput.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import com.gargoylesoftware.htmlunit.SgmlPage;
 import com.gargoylesoftware.htmlunit.html.impl.SelectableTextInput;
 import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Wrapper for the HTML element "input" where type is "date".
@@ -192,7 +193,7 @@ public class HtmlDateInput extends HtmlInput implements SelectableTextInput {
     @Override
     public void setValueAttribute(final String newValue) {
         try {
-            if (hasFeature(JS_INPUT_SET_VALUE_DATE_SUPPORTED)) {
+            if (hasFeature(JS_INPUT_SET_VALUE_DATE_SUPPORTED) && StringUtils.isNotEmpty(newValue)) {
                 FORMATTER_.parse(newValue);
             }
             super.setValueAttribute(newValue);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateTimeLocalInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateTimeLocalInput.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Map;
 
 import com.gargoylesoftware.htmlunit.SgmlPage;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Wrapper for the HTML element "input" where type is "datetime-local".
@@ -59,7 +60,8 @@ public class HtmlDateTimeLocalInput extends HtmlInput {
     public void setValueAttribute(final String newValue) {
         try {
             if (hasFeature(HTMLINPUT_TYPE_DATETIME_SUPPORTED)
-                    && !hasFeature(HTMLINPUT_TYPE_MONTH_NOT_SUPPORTED)) {
+                    && !hasFeature(HTMLINPUT_TYPE_MONTH_NOT_SUPPORTED)
+                    && StringUtils.isNotEmpty(newValue)) {
                 FORMATTER_.parse(newValue);
             }
             super.setValueAttribute(newValue);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlMonthInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlMonthInput.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Map;
 
 import com.gargoylesoftware.htmlunit.SgmlPage;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Wrapper for the HTML element "input" where type is "month".
@@ -59,7 +60,8 @@ public class HtmlMonthInput extends HtmlInput {
     public void setValueAttribute(final String newValue) {
         try {
             if (hasFeature(HTMLINPUT_TYPE_DATETIME_SUPPORTED)
-                    && !hasFeature(HTMLINPUT_TYPE_MONTH_NOT_SUPPORTED)) {
+                    && !hasFeature(HTMLINPUT_TYPE_MONTH_NOT_SUPPORTED)
+                    && StringUtils.isNotEmpty(newValue)) {
                 FORMATTER_.parse(newValue);
             }
             super.setValueAttribute(newValue);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlRangeInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlRangeInput.java
@@ -17,6 +17,7 @@ package com.gargoylesoftware.htmlunit.html;
 import java.util.Map;
 
 import com.gargoylesoftware.htmlunit.SgmlPage;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Wrapper for the HTML element "input" where type is "range".
@@ -125,7 +126,11 @@ public class HtmlRangeInput extends HtmlInput {
     @Override
     public void setValueAttribute(final String newValue) {
         try {
-            setValueAttribute(Double.parseDouble(newValue));
+            if (StringUtils.isNotEmpty(newValue)) {
+                setValueAttribute(Double.parseDouble(newValue));
+            } else {
+                super.setValueAttribute(newValue);
+            }
         }
         catch (final NumberFormatException e) {
             // ignore

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTimeInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTimeInput.java
@@ -21,6 +21,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Map;
 
 import com.gargoylesoftware.htmlunit.SgmlPage;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Wrapper for the HTML element "input" where type is "time".
@@ -57,7 +58,7 @@ public class HtmlTimeInput extends HtmlInput {
     @Override
     public void setValueAttribute(final String newValue) {
         try {
-            if (hasFeature(HTMLINPUT_TYPE_DATETIME_SUPPORTED)) {
+            if (hasFeature(HTMLINPUT_TYPE_DATETIME_SUPPORTED) && StringUtils.isNotEmpty(newValue)) {
                 FORMATTER_.parse(newValue);
             }
             super.setValueAttribute(newValue);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlWeekInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlWeekInput.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Map;
 
 import com.gargoylesoftware.htmlunit.SgmlPage;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Wrapper for the HTML element "input" where type is "week".
@@ -59,7 +60,8 @@ public class HtmlWeekInput extends HtmlInput {
     public void setValueAttribute(final String newValue) {
         try {
             if (hasFeature(HTMLINPUT_TYPE_DATETIME_SUPPORTED)
-                    && !hasFeature(HTMLINPUT_TYPE_MONTH_NOT_SUPPORTED)) {
+                    && !hasFeature(HTMLINPUT_TYPE_MONTH_NOT_SUPPORTED)
+                    && StringUtils.isNotEmpty(newValue)) {
                 FORMATTER_.parse(newValue);
             }
             super.setValueAttribute(newValue);

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlColorInputTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlColorInputTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import com.gargoylesoftware.htmlunit.BrowserRunner;
@@ -59,12 +60,36 @@ public class HtmlColorInputTest extends WebDriverTestCase {
     }
 
     /**
+     * Verifies clear().
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts("")
+    public void clearInput() throws Exception {
+        final String htmlContent
+                = "<html>\n"
+                + "<head></head>\n"
+                + "<body>\n"
+                + "<form id='form1'>\n"
+                + "  <input type='color' name='tester' id='tester' value='#ff0000'>\n"
+                + "</form>\n"
+                + "</body></html>";
+
+        final WebDriver driver = loadPage2(htmlContent);
+        final WebElement element = driver.findElement(By.id("tester"));
+
+        element.clear();
+        assertEquals("", element.getAttribute("value"));
+    }
+
+    /**
      * @throws Exception if the test fails
      */
     @Test
     @Alerts("--")
     public void minMaxStep() throws Exception {
-        final String html = "<html>\n"
+        final String html
+            = "<html>\n"
             + "<head>\n"
             + "<script>\n"
             + "  function test() {\n"

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlDateInputTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlDateInputTest.java
@@ -23,6 +23,7 @@ import com.gargoylesoftware.htmlunit.BrowserRunner;
 import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
 import com.gargoylesoftware.htmlunit.BrowserRunner.BuggyWebDriver;
 import com.gargoylesoftware.htmlunit.WebDriverTestCase;
+import org.openqa.selenium.WebElement;
 
 /**
  * Tests for {@link HtmlDateInput}.
@@ -89,6 +90,48 @@ public class HtmlDateInputTest extends WebDriverTestCase {
         driver.findElement(By.id("tester")).click();
 
         verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts("")
+    public void clearDateInput() throws Exception {
+        final String html =
+              "<html>\n"
+              + "<body>\n"
+              + "  <input id='input' type='date' value='2018-03-22'>\n"
+              + "</body></html>";
+
+        final WebDriver driver = loadPage2(html);
+        WebElement input = driver.findElement(By.id("input"));
+
+        assertEquals("2018-03-22", input.getAttribute("value"));
+
+        input.clear();
+        assertEquals("", input.getAttribute("value"));
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts("")
+    public void clearDateTimeInput() throws Exception {
+        final String html =
+              "<html>\n"
+              + "<body>\n"
+              + "  <input id='input' type='datetime-local' value='2018-03-22T10:10'>\n"
+              + "</body></html>";
+
+        final WebDriver driver = loadPage2(html);
+        WebElement input = driver.findElement(By.id("input"));
+
+        assertEquals("2018-03-22T10:10", input.getAttribute("value"));
+
+        input.clear();
+        assertEquals("", input.getAttribute("value"));
     }
 
     /**

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInputTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInputTest.java
@@ -718,4 +718,26 @@ public class HtmlNumberInputTest extends WebDriverTestCase {
 
         loadPageWithAlerts2(html);
     }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts("")
+    public void clearInput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "<form>\n"
+            + "  <input type='number' id='tester' value='10'>\n"
+            + "</form>\n"
+            + "</body>\n"
+            + "</html>";
+
+        WebDriver driver = loadPage2(html);
+        WebElement element = driver.findElement(By.id("tester"));
+        assertEquals("10", element.getAttribute("value"));
+
+        element.clear();
+        assertEquals("", element.getAttribute("value"));
+    }
 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlRangeInputTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlRangeInputTest.java
@@ -20,6 +20,9 @@ import org.junit.runner.RunWith;
 import com.gargoylesoftware.htmlunit.BrowserRunner;
 import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
 import com.gargoylesoftware.htmlunit.WebDriverTestCase;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 /**
  * Tests for {@link HtmlRangeInput}.
@@ -307,5 +310,26 @@ public class HtmlRangeInputTest extends WebDriverTestCase {
             + "</body></html>";
 
         loadPageWithAlerts2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts("")
+    public void clearInput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "<form>\n"
+            + "  <input type='range' id='tester' value='5.6'>\n"
+            + "</form>\n"
+            + "</body>\n"
+            + "</html>";
+
+        WebDriver driver = loadPage2(html);
+        WebElement element = driver.findElement(By.id("tester"));
+        element.clear();
+
+        assertEquals("", element.getAttribute("value"));
     }
 }


### PR DESCRIPTION
Some inputs, such as date, datetime, range, and week were not cleanable since they only accept setting valid values. This makes them either accept valid values or and empty string. Other fields such as email or URL were already accepting empty String when setting the value attribute.

I noticed this while working with Selenium's htmlunit-driver. There is a `clear` method there which calls `setValueAttribute` with and empty String:

https://github.com/SeleniumHQ/htmlunit-driver/blob/dcab0f9e0ffc3a15625dfa8866997b42eb6b2e0c/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitWebElement.java#L233

But since a bunch of them don't accept it as a valid value, them it makes impossible to clear the field without resorting to workarounds.