### PR TITLE
Attachment handling: Content-Disposition and page navigation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1077,6 +1077,9 @@
         <contributor>
             <name>Le Stephane</name>
         </contributor>
+        <contributor>
+            <name>Alex Gorbatovsky</name>
+        </contributor>
     </contributors>
     <dependencies>
         <dependency>

--- a/src/main/java/com/gargoylesoftware/htmlunit/WebClient.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/WebClient.java
@@ -540,7 +540,7 @@ public class WebClient implements Serializable, AutoCloseable {
             final WebWindow w = openWindow(null, null, webWindow);
             final Page page = pageCreator_.createPage(webResponse, w);
             attachmentHandler_.handleAttachment(page);
-            return page;
+            return webWindow.getEnclosedPage();
         }
 
         final Page oldPage = webWindow.getEnclosedPage();

--- a/src/main/java/com/gargoylesoftware/htmlunit/attachment/AttachmentHandler.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/attachment/AttachmentHandler.java
@@ -62,6 +62,6 @@ public interface AttachmentHandler extends Serializable {
         if (disp == null) {
             return false;
         }
-        return disp.startsWith("attachment");
+        return disp.toLowerCase().startsWith("attachment");
     }
 }


### PR DESCRIPTION
Attachment handling improvements:

1) When detecting attachments, the disposition type should match "attachment" *case-insensitively*.
I had a few websites that had "Content-Disposition: Attachment" and HtmlUnit failed to detect it.
Reference: https://tools.ietf.org/html/rfc6266
2) When attachment is handled by user-defined handler, the WebClient should stay on the same page. Navigating to the attachment "page" result in non-HTML page loaded to the client, preventing it from running any additional HTML commands.