### PR TITLE
HtmlLabel.getReferencedElement() tests and fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1166,7 +1166,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1166,7 +1166,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,6 +8,11 @@
 
     <body>
         <release version="2.39.0" date="xxxx, 2020" description="Bugfixes, Firefox74">
+            <action type="fix" dev="fdanek">
+                HtmlLabel.getReferencedElement() now also supports HtmlButton, HtmlMeter,
+                HtmlOutput, HtmlProgress, HtmlSelect and HtmlTextArea in nested variant
+                and ignores not labelable elements in both variants.
+            </action>
             <action type="fix" dev="rbri" issue="#140">
                 WorkerGlobalScope.importScripts() now checks the content type of the
                 script to import.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlButton.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlButton.java
@@ -45,7 +45,7 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlButton extends HtmlElement implements DisabledElement, SubmittableElement, FormFieldWithNameHistory {
+public class HtmlButton extends HtmlElement implements DisabledElement, SubmittableElement, LabelableElement, FormFieldWithNameHistory {
 
     private static final Log LOG = LogFactory.getLog(HtmlButton.class);
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlButtonInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlButtonInput.java
@@ -28,7 +28,7 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlButtonInput extends HtmlInput {
+public class HtmlButtonInput extends HtmlInput implements LabelableElement {
 
     /**
      * Creates an instance.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlCheckBoxInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlCheckBoxInput.java
@@ -39,7 +39,7 @@ import com.gargoylesoftware.htmlunit.javascript.host.event.Event;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlCheckBoxInput extends HtmlInput {
+public class HtmlCheckBoxInput extends HtmlInput implements LabelableElement {
 
     /**
      * Value to use if no specified <tt>value</tt> attribute.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlColorInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlColorInput.java
@@ -29,8 +29,9 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
  */
-public class HtmlColorInput extends HtmlInput {
+public class HtmlColorInput extends HtmlInput implements LabelableElement {
 
     /**
      * Creates an instance.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateInput.java
@@ -32,8 +32,9 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
  */
-public class HtmlDateInput extends HtmlInput implements SelectableTextInput {
+public class HtmlDateInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
     private static DateTimeFormatter FORMATTER_ = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateTimeLocalInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlDateTimeLocalInput.java
@@ -29,8 +29,9 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * Wrapper for the HTML element "input" where type is "datetime-local".
  *
  * @author Ahmed Ashour
+ * @author Frank Danek
  */
-public class HtmlDateTimeLocalInput extends HtmlInput {
+public class HtmlDateTimeLocalInput extends HtmlInput implements LabelableElement {
 
     private static DateTimeFormatter FORMATTER_ = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlEmailInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlEmailInput.java
@@ -29,8 +29,9 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
  */
-public class HtmlEmailInput extends HtmlInput implements SelectableTextInput {
+public class HtmlEmailInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
     private SelectableTextSelectionDelegate selectionDelegate_ = new SelectableTextSelectionDelegate(this);
     private DoTypeProcessor doTypeProcessor_ = new DoTypeProcessor(this);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlFileInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlFileInput.java
@@ -41,7 +41,7 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
  * @author Frank Danek
  * @author Ronald Brill
  */
-public class HtmlFileInput extends HtmlInput {
+public class HtmlFileInput extends HtmlInput implements LabelableElement {
 
     private String contentType_;
     private byte[] data_;

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlImageInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlImageInput.java
@@ -53,7 +53,7 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlImageInput extends HtmlInput {
+public class HtmlImageInput extends HtmlInput implements LabelableElement {
 
     // For click with x, y position.
     private boolean wasPositionSpecified_;

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlLabel.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlLabel.java
@@ -130,32 +130,21 @@ public class HtmlLabel extends HtmlElement {
         if (!ATTRIBUTE_NOT_DEFINED.equals(elementId)) {
             try {
                 HtmlElement element = ((HtmlPage) getPage()).getHtmlElementById(elementId);
-                if (isLabelableElement(element)) {
-                	return element;
+                if (element instanceof LabelableElement) {
+                    return element;
                 }
             }
             catch (final ElementNotFoundException e) {
                 return null;
             }
         } else {
-	        for (final DomNode element : getChildren()) {
-	            if (isLabelableElement(element)) {
-	                return (HtmlElement) element;
-	            }
-	        }
+            for (final DomNode element : getChildren()) {
+                if (element instanceof LabelableElement) {
+                    return (HtmlElement) element;
+                }
+            }
         }
         return null;
-    }
-
-    private boolean isLabelableElement(DomNode element) {
-    	// TODO maybe we should introduce an interface LabelabelElement for this?
-    	return element instanceof HtmlButton
-			|| element instanceof HtmlInput && !(element instanceof HtmlHiddenInput)
-			|| element instanceof HtmlMeter
-			|| element instanceof HtmlOutput
-			|| element instanceof HtmlProgress
-			|| element instanceof HtmlSelect
-			|| element instanceof HtmlTextArea;
     }
 
     /**

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlLabel.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlLabel.java
@@ -129,18 +129,33 @@ public class HtmlLabel extends HtmlElement {
         final String elementId = getForAttribute();
         if (!ATTRIBUTE_NOT_DEFINED.equals(elementId)) {
             try {
-                return ((HtmlPage) getPage()).getHtmlElementById(elementId);
+                HtmlElement element = ((HtmlPage) getPage()).getHtmlElementById(elementId);
+                if (isLabelableElement(element)) {
+                	return element;
+                }
             }
             catch (final ElementNotFoundException e) {
                 return null;
             }
-        }
-        for (final DomNode element : getChildren()) {
-            if (element instanceof HtmlInput) {
-                return (HtmlInput) element;
-            }
+        } else {
+	        for (final DomNode element : getChildren()) {
+	            if (isLabelableElement(element)) {
+	                return (HtmlElement) element;
+	            }
+	        }
         }
         return null;
+    }
+
+    private boolean isLabelableElement(DomNode element) {
+    	// TODO maybe we should introduce an interface LabelabelElement for this?
+    	return element instanceof HtmlButton
+			|| element instanceof HtmlInput && !(element instanceof HtmlHiddenInput)
+			|| element instanceof HtmlMeter
+			|| element instanceof HtmlOutput
+			|| element instanceof HtmlProgress
+			|| element instanceof HtmlSelect
+			|| element instanceof HtmlTextArea;
     }
 
     /**

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlMeter.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlMeter.java
@@ -28,7 +28,7 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlMeter extends HtmlMedia {
+public class HtmlMeter extends HtmlMedia implements LabelableElement {
 
     /** The HTML tag represented by this element. */
     public static final String TAG_NAME = "meter";

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlMonthInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlMonthInput.java
@@ -29,8 +29,9 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * Wrapper for the HTML element "input" where type is "month".
  *
  * @author Ahmed Ashour
+ * @author Frank Danek
  */
-public class HtmlMonthInput extends HtmlInput {
+public class HtmlMonthInput extends HtmlInput implements LabelableElement {
 
     private static DateTimeFormatter FORMATTER_ = DateTimeFormatter.ofPattern("yyyy-MM");
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInput.java
@@ -30,8 +30,9 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
  */
-public class HtmlNumberInput extends HtmlInput implements SelectableTextInput {
+public class HtmlNumberInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
     private SelectableTextSelectionDelegate selectionDelegate_ = new SelectableTextSelectionDelegate(this);
     private DoTypeProcessor doTypeProcessor_ = new DoTypeProcessor(this);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlOutput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlOutput.java
@@ -24,7 +24,7 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlOutput extends HtmlElement {
+public class HtmlOutput extends HtmlElement implements LabelableElement {
 
     /** The HTML tag represented by this element. */
     public static final String TAG_NAME = "output";

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlPasswordInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlPasswordInput.java
@@ -33,7 +33,7 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlPasswordInput extends HtmlInput implements SelectableTextInput {
+public class HtmlPasswordInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
     private SelectableTextSelectionDelegate selectionDelegate_ = new SelectableTextSelectionDelegate(this);
     private DoTypeProcessor doTypeProcessor_ = new DoTypeProcessor(this);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlProgress.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlProgress.java
@@ -27,7 +27,7 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlProgress extends HtmlElement {
+public class HtmlProgress extends HtmlElement implements LabelableElement {
 
     /** The HTML tag represented by this element. */
     public static final String TAG_NAME = "progress";

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlRadioButtonInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlRadioButtonInput.java
@@ -41,7 +41,7 @@ import com.gargoylesoftware.htmlunit.javascript.host.event.Event;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlRadioButtonInput extends HtmlInput {
+public class HtmlRadioButtonInput extends HtmlInput implements LabelableElement {
 
     /**
      * Value to use if no specified <tt>value</tt> attribute.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlRangeInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlRangeInput.java
@@ -25,8 +25,9 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
  */
-public class HtmlRangeInput extends HtmlInput {
+public class HtmlRangeInput extends HtmlInput implements LabelableElement {
 
     /**
      * Creates an instance.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlResetInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlResetInput.java
@@ -33,7 +33,7 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlResetInput extends HtmlInput {
+public class HtmlResetInput extends HtmlInput implements LabelableElement {
 
     /**
      * Value to use if no specified <tt>value</tt> attribute.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlSelect.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlSelect.java
@@ -49,7 +49,7 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlSelect extends HtmlElement implements DisabledElement, SubmittableElement, FormFieldWithNameHistory {
+public class HtmlSelect extends HtmlElement implements DisabledElement, SubmittableElement, LabelableElement, FormFieldWithNameHistory {
 
     /** The HTML tag represented by this element. */
     public static final String TAG_NAME = "select";

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlSubmitInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlSubmitInput.java
@@ -37,7 +37,7 @@ import com.gargoylesoftware.htmlunit.util.StringUtils;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlSubmitInput extends HtmlInput {
+public class HtmlSubmitInput extends HtmlInput implements LabelableElement {
 
     /**
      * Value to use if no specified <tt>value</tt> attribute.

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTelInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTelInput.java
@@ -25,8 +25,9 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
  */
-public class HtmlTelInput extends HtmlInput implements SelectableTextInput {
+public class HtmlTelInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
     private SelectableTextSelectionDelegate selectionDelegate_ = new SelectableTextSelectionDelegate(this);
     private DoTypeProcessor doTypeProcessor_ = new DoTypeProcessor(this);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTextArea.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTextArea.java
@@ -51,7 +51,7 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlTextArea extends HtmlElement implements DisabledElement, SubmittableElement, SelectableTextInput,
+public class HtmlTextArea extends HtmlElement implements DisabledElement, SubmittableElement, LabelableElement, SelectableTextInput,
     FormFieldWithNameHistory {
     /** The HTML tag represented by this element. */
     public static final String TAG_NAME = "textarea";

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTextInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTextInput.java
@@ -34,7 +34,7 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  * @author Ronald Brill
  * @author Frank Danek
  */
-public class HtmlTextInput extends HtmlInput implements SelectableTextInput {
+public class HtmlTextInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
     private SelectableTextSelectionDelegate selectionDelegate_ = new SelectableTextSelectionDelegate(this);
     private DoTypeProcessor doTypeProcessor_ = new DoTypeProcessor(this);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTimeInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTimeInput.java
@@ -28,8 +28,9 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * Wrapper for the HTML element "input" where type is "time".
  *
  * @author Ahmed Ashour
+ * @author Frank Danek
  */
-public class HtmlTimeInput extends HtmlInput {
+public class HtmlTimeInput extends HtmlInput implements LabelableElement {
 
     private static DateTimeFormatter FORMATTER_ = DateTimeFormatter.ofPattern("HH:mm");
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlUrlInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlUrlInput.java
@@ -29,8 +29,9 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
  */
-public class HtmlUrlInput extends HtmlInput implements SelectableTextInput {
+public class HtmlUrlInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
     private SelectableTextSelectionDelegate selectionDelegate_ = new SelectableTextSelectionDelegate(this);
     private DoTypeProcessor doTypeProcessor_ = new DoTypeProcessor(this);

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlWeekInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlWeekInput.java
@@ -29,8 +29,9 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  * Wrapper for the HTML element "input" where type is "week".
  *
  * @author Ahmed Ashour
+ * @author Frank Danek
  */
-public class HtmlWeekInput extends HtmlInput {
+public class HtmlWeekInput extends HtmlInput implements LabelableElement {
 
     private static DateTimeFormatter FORMATTER_ = DateTimeFormatter.ofPattern("yyyy-'W'ww");
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/LabelableElement.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/LabelableElement.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2020 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gargoylesoftware.htmlunit.html;
+
+/**
+ * A marker interface for those element that can be labeled.
+ * @see <a href="https://html.spec.whatwg.org/multipage/forms.html#category-label">HTML spec</a>
+ *
+ * @author Frank Danek
+ */
+public interface LabelableElement {
+
+}

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlLabelTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlLabelTest.java
@@ -26,7 +26,6 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import com.gargoylesoftware.htmlunit.BrowserRunner;
 import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
-import com.gargoylesoftware.htmlunit.BrowserRunner.BuggyWebDriver;
 import com.gargoylesoftware.htmlunit.BrowserRunner.NotYetImplemented;
 import com.gargoylesoftware.htmlunit.WebDriverTestCase;
 
@@ -213,9 +212,9 @@ public class HtmlLabelTest extends WebDriverTestCase {
             final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
             HtmlLabel label = page.getHtmlElementById("label1");
             if (getBrowserVersion().isIE()) {
-            	assertNull(label.getReferencedElement());
+                assertNull(label.getReferencedElement());
             } else {
-            	assertEquals("meter1", label.getReferencedElement().getId());
+                assertEquals("meter1", label.getReferencedElement().getId());
             }
         }
     }
@@ -236,9 +235,9 @@ public class HtmlLabelTest extends WebDriverTestCase {
             final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
             HtmlLabel label = page.getHtmlElementById("label1");
             if (getBrowserVersion().isIE()) {
-            	assertNull(label.getReferencedElement());
+                assertNull(label.getReferencedElement());
             } else {
-            	assertEquals("output1", label.getReferencedElement().getId());
+                assertEquals("output1", label.getReferencedElement().getId());
             }
         }
     }
@@ -258,30 +257,30 @@ public class HtmlLabelTest extends WebDriverTestCase {
         if (driver instanceof HtmlUnitDriver) {
             final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
             HtmlLabel label = page.getHtmlElementById("label1");
-        	assertEquals("progress1", label.getReferencedElement().getId());
+            assertEquals("progress1", label.getReferencedElement().getId());
         }
     }
 
     /**
-	 * @throws Exception if the test fails
-	 */
-	@Test
-	public void getReferencedElementForSelect() throws Exception {
-	    final String html = "<html>\n"
-	        + "<body>\n"
-	        + "  <label id='label1' for='select1'>Item</label>\n"
-	        + "  <select id='select1'><option>Option</option></select>\n"
-	        + "</body></html>";
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForSelect() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='select1'>Item</label>\n"
+            + "  <select id='select1'><option>Option</option></select>\n"
+            + "</body></html>";
 
-	    final WebDriver driver = loadPageWithAlerts2(html);
-	    if (driver instanceof HtmlUnitDriver) {
-	        final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
-	        HtmlLabel label = page.getHtmlElementById("label1");
-	        assertEquals("select1", label.getReferencedElement().getId());
-	    }
-	}
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("select1", label.getReferencedElement().getId());
+        }
+    }
 
-	/**
+    /**
      * @throws Exception if the test fails
      */
     @Test
@@ -320,7 +319,7 @@ public class HtmlLabelTest extends WebDriverTestCase {
         }
     }
 
-	/**
+    /**
      * @throws Exception if the test fails
      */
     @Test
@@ -383,7 +382,7 @@ public class HtmlLabelTest extends WebDriverTestCase {
         }
     }
 
-	/**
+    /**
      * @throws Exception if the test fails
      */
     @Test
@@ -401,14 +400,14 @@ public class HtmlLabelTest extends WebDriverTestCase {
             final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
             HtmlLabel label = page.getHtmlElementById("label1");
             if (getBrowserVersion().isIE()) {
-            	assertNull(label.getReferencedElement());
+                assertNull(label.getReferencedElement());
             } else {
-            	assertEquals("meter1", label.getReferencedElement().getId());
+                assertEquals("meter1", label.getReferencedElement().getId());
             }
         }
     }
 
-	/**
+    /**
      * @throws Exception if the test fails
      */
     @Test
@@ -426,14 +425,14 @@ public class HtmlLabelTest extends WebDriverTestCase {
             final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
             HtmlLabel label = page.getHtmlElementById("label1");
             if (getBrowserVersion().isIE()) {
-            	assertNull(label.getReferencedElement());
+                assertNull(label.getReferencedElement());
             } else {
-            	assertEquals("output1", label.getReferencedElement().getId());
+                assertEquals("output1", label.getReferencedElement().getId());
             }
         }
     }
 
-	/**
+    /**
      * @throws Exception if the test fails
      */
     @Test
@@ -450,32 +449,32 @@ public class HtmlLabelTest extends WebDriverTestCase {
         if (driver instanceof HtmlUnitDriver) {
             final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
             HtmlLabel label = page.getHtmlElementById("label1");
-        	assertEquals("progress1", label.getReferencedElement().getId());
+            assertEquals("progress1", label.getReferencedElement().getId());
         }
     }
 
     /**
-	 * @throws Exception if the test fails
-	 */
-	@Test
-	public void getReferencedElementNestedSelect() throws Exception {
-	    final String html = "<html>\n"
-	        + "<body>\n"
-	        + "  <label id='label1'>Item\n"
-	        + "    <select id='select1'><option>Option</option></select>\n"
-	        + "    <select id='select2'><option>Option</option></select>\n"
-	        + "  </label>\n"
-	        + "</body></html>";
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedSelect() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <select id='select1'><option>Option</option></select>\n"
+            + "    <select id='select2'><option>Option</option></select>\n"
+            + "  </label>\n"
+            + "</body></html>";
 
-	    final WebDriver driver = loadPageWithAlerts2(html);
-	    if (driver instanceof HtmlUnitDriver) {
-	        final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
-	        HtmlLabel label = page.getHtmlElementById("label1");
-	        assertEquals("select1", label.getReferencedElement().getId());
-	    }
-	}
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("select1", label.getReferencedElement().getId());
+        }
+    }
 
-	/**
+    /**
      * @throws Exception if the test fails
      */
     @Test

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlLabelTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlLabelTest.java
@@ -26,6 +26,7 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import com.gargoylesoftware.htmlunit.BrowserRunner;
 import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
+import com.gargoylesoftware.htmlunit.BrowserRunner.BuggyWebDriver;
 import com.gargoylesoftware.htmlunit.BrowserRunner.NotYetImplemented;
 import com.gargoylesoftware.htmlunit.WebDriverTestCase;
 
@@ -64,15 +65,745 @@ public class HtmlLabelTest extends WebDriverTestCase {
     }
 
     /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNone() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item</label>\n"
+            + "  <input type='text' id='text1'>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPage2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForEmpty() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for=''>Item</label>\n"
+            + "  <input type='text' id='text1'>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForUnknown() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='unknwon'>Item</label>\n"
+            + "  <input type='text' id='text1'>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForNotLabelable() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='div1'>Item</label>\n"
+            + "  <div id='div1'></div>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForButton() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='button1'>Item</label>\n"
+            + "  <button id='button1'></button>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("button1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForInput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='text1'>Item</label>\n"
+            + "  <input type='text' id='text1'>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("text1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForInputHidden() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='hidden1'>Item</label>\n"
+            + "  <input type='hidden' id='hidden1'>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForMeter() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='meter1'>Item</label>\n"
+            + "  <meter id='meter1'></meter>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            if (getBrowserVersion().isIE()) {
+            	assertNull(label.getReferencedElement());
+            } else {
+            	assertEquals("meter1", label.getReferencedElement().getId());
+            }
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForOutput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='output1'>Item</label>\n"
+            + "  <output id='output1'></output>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            if (getBrowserVersion().isIE()) {
+            	assertNull(label.getReferencedElement());
+            } else {
+            	assertEquals("output1", label.getReferencedElement().getId());
+            }
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForProgress() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='progress1'>Item</label>\n"
+            + "  <progress id='progress1'></progress>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+        	assertEquals("progress1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+	 * @throws Exception if the test fails
+	 */
+	@Test
+	public void getReferencedElementForSelect() throws Exception {
+	    final String html = "<html>\n"
+	        + "<body>\n"
+	        + "  <label id='label1' for='select1'>Item</label>\n"
+	        + "  <select id='select1'><option>Option</option></select>\n"
+	        + "</body></html>";
+
+	    final WebDriver driver = loadPageWithAlerts2(html);
+	    if (driver instanceof HtmlUnitDriver) {
+	        final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+	        HtmlLabel label = page.getHtmlElementById("label1");
+	        assertEquals("select1", label.getReferencedElement().getId());
+	    }
+	}
+
+	/**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForTextArea() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='text1'>Item</label>\n"
+            + "  <textarea id='text1'></textarea>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("text1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedNotLabelable() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <div id='div1'></div>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+	/**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedButton() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <button id='button1'></button>\n"
+            + "    <button id='button2'></button>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("button1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedInput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <input type='text' id='text1'>\n"
+            + "    <input type='text' id='text2'>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("text1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedInputHidden() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <input type='hidden' id='hidden1'>\n"
+            + "    <input type='hidden' id='hidden2'>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+	/**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedMeter() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <meter id='meter1'></meter>\n"
+            + "    <meter id='meter2'></meter>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            if (getBrowserVersion().isIE()) {
+            	assertNull(label.getReferencedElement());
+            } else {
+            	assertEquals("meter1", label.getReferencedElement().getId());
+            }
+        }
+    }
+
+	/**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedOutput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <output id='output1'></output>\n"
+            + "    <output id='output2'></output>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            if (getBrowserVersion().isIE()) {
+            	assertNull(label.getReferencedElement());
+            } else {
+            	assertEquals("output1", label.getReferencedElement().getId());
+            }
+        }
+    }
+
+	/**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedProgress() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <progress id='progress1'></progress>\n"
+            + "    <progress id='progress2'></progress>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+        	assertEquals("progress1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+	 * @throws Exception if the test fails
+	 */
+	@Test
+	public void getReferencedElementNestedSelect() throws Exception {
+	    final String html = "<html>\n"
+	        + "<body>\n"
+	        + "  <label id='label1'>Item\n"
+	        + "    <select id='select1'><option>Option</option></select>\n"
+	        + "    <select id='select2'><option>Option</option></select>\n"
+	        + "  </label>\n"
+	        + "</body></html>";
+
+	    final WebDriver driver = loadPageWithAlerts2(html);
+	    if (driver instanceof HtmlUnitDriver) {
+	        final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+	        HtmlLabel label = page.getHtmlElementById("label1");
+	        assertEquals("select1", label.getReferencedElement().getId());
+	    }
+	}
+
+	/**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementNestedTextArea() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1'>Item\n"
+            + "    <textarea id='text1'></textarea>\n"
+            + "    <textarea id='text2'></textarea>\n"
+            + "  </label>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("text1", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForVersusNested() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='text2'>Item\n"
+            + "    <input type='text' id='text1'>\n"
+            + "  </label>\n"
+            + "  <input type='text' id='text2'>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertEquals("text2", label.getReferencedElement().getId());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForUnknownVersusNested() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='unknown'>Item\n"
+            + "    <input type='text' id='text1'>\n"
+            + "  </label>\n"
+            + "  <input type='text' id='text2'>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getReferencedElementForNotLabelableVersusNested() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='div1'>Item\n"
+            + "    <input type='text' id='text1'>\n"
+            + "  </label>\n"
+            + "  <div id='div1'></div>\n"
+            + "</body></html>";
+
+        final WebDriver driver = loadPageWithAlerts2(html);
+        if (driver instanceof HtmlUnitDriver) {
+            final HtmlPage page = (HtmlPage) getWebWindowOf((HtmlUnitDriver) driver).getEnclosedPage();
+            HtmlLabel label = page.getHtmlElementById("label1");
+            assertNull(label.getReferencedElement());
+        }
+    }
+
+    /**
      * @throws Exception if an error occurs
      */
     @Test
-    @Alerts({"labelclick", "chboxclick"})
-    public void clickFor() throws Exception {
+    @Alerts({"labelclick"})
+    public void clickNone() throws Exception {
         final String html = "<html>\n"
             + "<body>\n"
-            + "  <label id='label1' for='checkbox1' onclick='alert(\"labelclick\")'>Toggle checkbox</label>\n"
-            + "  <input type='checkbox' id='checkbox1' onclick='alert(\"chboxclick\")'>\n"
+            + "  <label id='label1' onclick='alert(\"labelclick\")'>Click me</label>\n"
+            + "  <input type='text' id='text1' onclick='alert(\"textclick\")'>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick"})
+    public void clickForEmpty() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='' onclick='alert(\"labelclick\")'>Click me</label>\n"
+            + "  <input type='text' id='text1' onclick='alert(\"textclick\")'>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick"})
+    public void clickForUnknown() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='unknown' onclick='alert(\"labelclick\")'>Click me</label>\n"
+            + "  <input type='text' id='text1' onclick='alert(\"textclick\")'>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick"})
+    public void clickForNotLabelable() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='div1' onclick='alert(\"labelclick\")'>Click me</label>\n"
+            + "  <div id='div1' onclick='alert(\"textclick\")'></div>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick", "textclick"})
+    public void clickForInput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='text1' onclick='alert(\"labelclick\")'>Click me</label>\n"
+            + "  <input type='text' id='text1' onclick='alert(\"textclick\")'>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick", "textclick"})
+    public void clickForTextArea() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='text1' onclick='alert(\"labelclick\")'>Click me</label>\n"
+            + "  <textarea id='text1' onclick='alert(\"textclick\")'></textarea>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick", "selectclick"})
+    public void clickForSelect() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='select1' onclick='alert(\"labelclick\")'>Click me</label>\n"
+            + "  <select id='select1' onclick='alert(\"selectclick\")'><option>Option</option></select>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick"})
+    public void clickNestedNotLabelable() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' onclick='alert(\"labelclick\")'>Click me"
+            // we have to add some extra text to make Selenium click the label and not the nested element
+            + " (we have to add some extra text to make Selenium click the label and not the nested element)\n"
+            + "    <div id='div1' onclick='alert(\"textclick\")'></div>\n"
+            + "  </label>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick", "text1click"})
+    public void clickNestedInput() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' onclick='alert(\"labelclick\")'>Click me"
+            // we have to add some extra text to make Selenium click the label and not the nested element
+            + " (we have to add some extra text to make Selenium click the label and not the nested element)\n"
+            + "    <input type='text' id='text1' onclick='alert(\"text1click\")'>\n"
+            + "    <input type='text' id='text2' onclick='alert(\"text2click\")'>\n"
+            + "  </label>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick", "text1click"})
+    public void clickNestedTextArea() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' onclick='alert(\"labelclick\")'>Click me"
+            // we have to add some extra text to make Selenium click the label and not the nested element
+            + " (we have to add some extra text to make Selenium click the label and not the nested element)\n"
+            + "    <textarea id='text1' onclick='alert(\"text1click\")'></textarea>\n"
+            + "    <textarea id='text2' onclick='alert(\"text2click\")'></textarea>\n"
+            + "  </label>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick", "select1click"})
+    public void clickNestedSelect() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' onclick='alert(\"labelclick\")'>Click me"
+            // we have to add some extra text to make Selenium click the label and not the nested element
+            + " (we have to add some extra text to make Selenium click the label and not the nested element)\n"
+            + "    <select id='select1' onclick='alert(\"select1click\")'><option>Option</option></select>\n"
+            + "    <select id='select2' onclick='alert(\"select2click\")'><option>Option</option></select>\n"
+            + "  </label>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick", "text2click"})
+    public void clickForVersusNested() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='text2' onclick='alert(\"labelclick\")'>Click me"
+            // we have to add some extra text to make Selenium click the label and not the nested element
+            + " (we have to add some extra text to make Selenium click the label and not the nested element)\n"
+            + "    <input type='text' id='text1' onclick='alert(\"text1click\")'>\n"
+            + "  </label>\n"
+            + "  <input type='text' id='text2' onclick='alert(\"text2click\")'>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick"})
+    public void clickForUnknownVersusNested() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='unknown' onclick='alert(\"labelclick\")'>Click me"
+            // we have to add some extra text to make Selenium click the label and not the nested element
+            + " (we have to add some extra text to make Selenium click the label and not the nested element)\n"
+            + "    <input type='text' id='text1' onclick='alert(\"text1click\")'>\n"
+            + "  </label>\n"
+            + "  <input type='text' id='text2' onclick='alert(\"text2click\")'>\n"
+            + "</body></html>";
+        final WebDriver driver = loadPage2(html);
+        driver.findElement(By.id("label1")).click();
+        verifyAlerts(driver, getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"labelclick"})
+    public void clickForNotLabelableVersusNested() throws Exception {
+        final String html = "<html>\n"
+            + "<body>\n"
+            + "  <label id='label1' for='div1' onclick='alert(\"labelclick\")'>Click me"
+            // we have to add some extra text to make Selenium click the label and not the nested element
+            + " (we have to add some extra text to make Selenium click the label and not the nested element)\n"
+            + "    <input type='text' id='text1' onclick='alert(\"text1click\")'>\n"
+            + "  </label>\n"
+            + "  <div id='div1' onclick='alert(\"textclick\")'></div>\n"
             + "</body></html>";
         final WebDriver driver = loadPage2(html);
         driver.findElement(By.id("label1")).click();


### PR DESCRIPTION
HtmlLabel.getReferencedElement() now also supports HtmlButton, HtmlMeter, HtmlOutput, HtmlProgress, HtmlSelect and HtmlTextArea in nested variant and ignores not labelable elements in both variants.

One ToDo added in HtmlLabel to be discussed.