### PR TITLE
Fix exception when handling invalid body element with no JS engine.

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,6 +8,9 @@
 
     <body>
         <release version="2.40.0" date="xxxx, 2020" description="Bugfixes, Chrome 81, Firefox75">
+            <action type="fix" dev="rbri" due-to="Ronny Shapiro">
+                Fix exception when handling invalid body element with no JS engine.
+            </action>
             <action type="fix" dev="rbri">
                 Label form property has to work based on the element referenced by the label.
             </action>

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
@@ -99,6 +99,7 @@ import net.sourceforge.htmlunit.cyberneko.HTMLTagBalancingListener;
  * @author Ronald Brill
  * @author Frank Danek
  * @author Carsten Steul
+ * @author Ronny Shapiro
  */
 final class HtmlUnitNekoDOMBuilder extends AbstractSAXParser
         implements ContentHandler, LexicalHandler, HTMLTagBalancingListener, HTMLParserDOMBuilder {
@@ -739,7 +740,8 @@ final class HtmlUnitNekoDOMBuilder extends AbstractSAXParser
             final String attrName = attrs.getLocalName(i).toLowerCase(Locale.ROOT);
             if (to.getAttributes().getNamedItem(attrName) == null) {
                 to.setAttribute(attrName, attrs.getValue(i));
-                if (attrName.startsWith("on") && to.getScriptableObject() instanceof HTMLBodyElement) {
+                if (attrName.startsWith("on") && to.getPage().getWebClient().isJavaScriptEngineEnabled() &&
+                        to.getScriptableObject() instanceof HTMLBodyElement) {
                     final HTMLBodyElement jsBody = to.getScriptableObject();
                     jsBody.createEventHandlerFromAttribute(attrName, attrs.getValue(i));
                 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/WebClient8Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/WebClient8Test.java
@@ -320,7 +320,7 @@ public class WebClient8Test extends SimpleWebTestCase {
                 + "  <title>foo</title>"
                 + "</head>"
                 + "<body>"
-                + "  <body onLoad=\"ready()\">"
+                + "  <body onLoad='ready()'>"
                 + "  </body>"
                 + "</body>"
                 + "</html>";

--- a/src/test/java/com/gargoylesoftware/htmlunit/WebClient8Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/WebClient8Test.java
@@ -309,4 +309,24 @@ public class WebClient8Test extends SimpleWebTestCase {
             assertEquals(page.getBody().getChildElementCount(), 1);
         }
     }
+
+    /**
+     * @throws Exception if something goes wrong
+     */
+    @Test
+    public void invalidElementEventWithNoJS() throws Exception {
+        final String html = "<html>"
+                + "<head>"
+                + "  <title>foo</title>"
+                + "</head>"
+                + "<body>"
+                + "  <body onLoad=\"ready()\">"
+                + "  </body>"
+                + "</body>"
+                + "</html>";
+
+        try (WebClient webClient = new WebClient(getBrowserVersion(), false, null, -1)) {
+            loadPage(webClient, html, null, URL_FIRST);
+        }
+    }
 }


### PR DESCRIPTION
When handling body elements with 'on' event in invalid position and discarding them an exception is thrown. This safety check fixes it.