### PR TITLE
Fix printing HtmlTemplate's children

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -9,6 +9,9 @@
     <body>
         <release version="2.41.0" date="xxxx, 2020" description="Bugfixes">
             <action type="fix" dev="rbri" due-to="Ronny Shapiro">
+                Properly print HtmlTemplate's children via asXml.
+            </action>
+            <action type="fix" dev="rbri" due-to="Ronny Shapiro">
                 Document getElementById(..) now returns null for elements inside a template tag.
             </action>
             <action type="fix" dev="rbri" due-to="Ronny Shapiro">

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTemplate.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlTemplate.java
@@ -14,6 +14,7 @@
  */
 package com.gargoylesoftware.htmlunit.html;
 
+import java.io.PrintWriter;
 import java.util.Map;
 
 import com.gargoylesoftware.htmlunit.SgmlPage;
@@ -23,6 +24,7 @@ import com.gargoylesoftware.htmlunit.SgmlPage;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Ronny Shapiro
  */
 public class HtmlTemplate extends HtmlElement {
 
@@ -75,6 +77,21 @@ public class HtmlTemplate extends HtmlElement {
             }
 
             domDocumentFragment_.appendChild(child);
+        }
+    }
+
+    @Override
+    protected boolean isEmptyXmlTagExpanded() {
+        // Force printing expanded tag if children in content
+        return getContent().getFirstChild() != null;
+    }
+
+    @Override
+    protected void printChildrenAsXml(final String indent, final PrintWriter printWriter) {
+        DomNode child = getContent().getFirstChild();
+        while (child != null) {
+            child.printXml(indent + "  ", printWriter);
+            child = child.getNextSibling();
         }
     }
 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlTemplateTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlTemplateTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2020 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gargoylesoftware.htmlunit.html;
+
+import com.gargoylesoftware.htmlunit.BrowserRunner;
+import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
+import com.gargoylesoftware.htmlunit.MockWebConnection;
+import com.gargoylesoftware.htmlunit.SimpleWebTestCase;
+import com.gargoylesoftware.htmlunit.WebClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for {@link HtmlTemplate}.
+ *
+ * @author Ronny Shapiro
+ */
+@RunWith(BrowserRunner.class)
+public class HtmlTemplateTest extends SimpleWebTestCase {
+
+    @Test
+    public void asXmlWithChildren() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "</head>\n"
+                + "<body>\n"
+                + "<template id='template'>\n"
+                + "<div></div>\n"
+                + "</template>\n"
+                + "</body>\n"
+                + "</html>";
+
+        HtmlPage htmlPage = loadPage(html);
+        assertEquals(htmlPage.getBody().asXml(), "<body>\r\n"
+                + "  <template id=\"template\">\r\n"
+                + "    <div>\r\n"
+                + "    </div>\r\n"
+                + "  </template>\r\n"
+                + "</body>\r\n");
+    }
+}


### PR DESCRIPTION
Using `isEmptyXmlTagExpanded` is somewhat abused but probably a better option than duplicating `printXml` entirely or doing a bigger change like using a 'getFirstChildForPrinting' and adding it to `DomElement`.