### PR TITLE
remove CSSStyleSheet System.out

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSStyleSheet.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSStyleSheet.java
@@ -944,7 +944,6 @@ public class CSSStyleSheet extends StyleSheet {
             final CSSOMParser parser = new CSSOMParser(new CSS3Parser());
             parser.setErrorHandler(errorHandler);
             ss = parser.parseStyleSheet(source, null);
-            System.out.println(errorHandler);
         }
         catch (final Throwable t) {
             if (LOG.isErrorEnabled()) {


### PR DESCRIPTION
I think that was left here unintentionally. It's also part of the 2.43 release line.