### PR TITLE
[#23] trigger readystatechange on XMLHttpRequest if registered via ad…

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/BrowserVersionFeatures.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/BrowserVersionFeatures.java
@@ -1608,6 +1608,12 @@ public enum BrowserVersionFeatures {
     XHR_FIRE_STATE_OPENED_AGAIN_IN_ASYNC_MODE,
 
     /**
+     * Indicates that the Browser handles async & sync network errors the same way.
+     */
+    @BrowserFeature({FF, FF68})
+    XHR_HANDLE_SYNC_NETWORK_ERRORS,
+
+    /**
      * Indicates if the port should be ignored during origin check.
      * For IE: this is currently a bug, see
      * http://connect.microsoft.com/IE/feedback/details/781303/

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/event/Event.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/event/Event.java
@@ -136,6 +136,21 @@ public class Event extends SimpleScriptable {
     /** The open event type, triggered by {@code onopen} event handlers. */
     public static final String TYPE_OPEN = "open";
 
+    /** The load start event type, triggered by {@code onloadstart} event handlers. */
+    public static final String TYPE_LOAD_START = "loadstart";
+
+    /** The load end event type, triggered by {@code onloadend} event handlers. */
+    public static final String TYPE_LOAD_END = "loadend";
+
+    /** The progress event type, triggered by {@code onprogress} event handlers. */
+    public static final String TYPE_PROGRESS = "progress";
+
+    /** The abort event type, triggered by {@code onabort} event handlers. */
+    public static final String TYPE_ABORT = "abort";
+
+    /** The timeout event type, triggered by {@code ontimeout} event handlers. */
+    public static final String TYPE_TIMEOUT = "timeout";
+
     /** No event phase. */
     @JsxConstant({CHROME, EDGE, FF, FF68})
     public static final short NONE = 0;

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/event/ProgressEvent.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/event/ProgressEvent.java
@@ -36,7 +36,7 @@ import net.sourceforge.htmlunit.corejs.javascript.Undefined;
 public class ProgressEvent extends Event {
 
     private boolean lengthComputable_;
-    private long loaded_;
+    private Object loaded_ = Undefined.instance;
     private long total_;
 
     /**
@@ -128,7 +128,7 @@ public class ProgressEvent extends Event {
      * @return the loaded property from the event.
      */
     @JsxGetter
-    public long getLoaded() {
+    public Object getLoaded() {
         return loaded_;
     }
 
@@ -137,7 +137,7 @@ public class ProgressEvent extends Event {
      *
      * @param loaded the loaded information for this event
      */
-    public void setLoaded(final long loaded) {
+    public void setLoaded(final Object loaded) {
         loaded_ = loaded;
     }
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest.java
@@ -249,7 +249,7 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
             }
 
             triggerJavascriptHandlers(getEventListenersContainer().getListeners(Event.TYPE_LOAD, false), paramOnLoad);
-            triggerJavascriptHandlers(getEventListenersContainer().getListeners(Event.TYPE_LOAD, false), paramOnLoad);
+            triggerJavascriptHandlers(getEventListenersContainer().getListeners(Event.TYPE_LOAD, true), paramOnLoad);
         }
     }
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequestEventTarget.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequestEventTarget.java
@@ -19,10 +19,14 @@ import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBr
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF68;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxConstructor;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxGetter;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxSetter;
+import com.gargoylesoftware.htmlunit.javascript.host.event.Event;
 import com.gargoylesoftware.htmlunit.javascript.host.event.EventTarget;
 
 import net.sourceforge.htmlunit.corejs.javascript.Function;
@@ -37,8 +41,7 @@ import net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime;
 @JsxClass
 public class XMLHttpRequestEventTarget extends EventTarget {
 
-    private Function loadHandler_;
-    private Function errorHandler_;
+    private final Map<String, Function> eventMapping_ = new HashMap<>();
 
     /**
      * Creates an instance.
@@ -54,13 +57,17 @@ public class XMLHttpRequestEventTarget extends EventTarget {
         throw ScriptRuntime.typeError("Illegal constructor.");
     }
 
+    public Function getFunctionForEvent(final String event) {
+        return eventMapping_.get(event);
+    }
+
     /**
      * Returns the event handler that fires on load.
      * @return the event handler that fires on load
      */
     @JsxGetter
     public Function getOnload() {
-        return loadHandler_;
+        return getFunctionForEvent(Event.TYPE_LOAD);
     }
 
     /**
@@ -69,7 +76,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnload(final Function loadHandler) {
-        loadHandler_ = loadHandler;
+        eventMapping_.put(Event.TYPE_LOAD, loadHandler);
     }
 
     /**
@@ -78,7 +85,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOnerror() {
-        return errorHandler_;
+        return getFunctionForEvent(Event.TYPE_ERROR);
     }
 
     /**
@@ -87,6 +94,114 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnerror(final Function errorHandler) {
-        errorHandler_ = errorHandler;
+        eventMapping_.put(Event.TYPE_ERROR, errorHandler);
+    }
+
+    /**
+     * Returns the event handler that fires on load start.
+     * @return the event handler that fires on load start
+     */
+    @JsxGetter
+    public Function getOnloadstart() {
+        return getFunctionForEvent(Event.TYPE_LOAD_START);
+    }
+
+    /**
+     * Sets the event handler that fires on load.
+     * @param loadHandler the event handler that fires on load
+     */
+    @JsxSetter
+    public void setOnloadstart(final Function loadHandler) {
+        eventMapping_.put(Event.TYPE_LOAD_START, loadHandler);
+    }
+
+    /**
+     * Returns the event handler that fires on load end.
+     * @return the event handler that fires on load end
+     */
+    @JsxGetter
+    public Function getOnloadend() {
+        return getFunctionForEvent(Event.TYPE_LOAD_END);
+    }
+
+    /**
+     * Sets the event handler that fires on load end.
+     * @param loadHandler the event handler that fires on loadend
+     */
+    @JsxSetter
+    public void setOnloadend(final Function loadHandler) {
+        eventMapping_.put(Event.TYPE_LOAD_END, loadHandler);
+    }
+
+    /**
+     * Returns the event handler that fires on progress.
+     * @return the event handler that fires on progress
+     */
+    @JsxGetter
+    public Function getOnprogress() {
+        return getFunctionForEvent(Event.TYPE_PROGRESS);
+    }
+
+    /**
+     * Sets the event handler that fires on progress.
+     * @param loadHandler the event handler that fires on progress
+     */
+    @JsxSetter
+    public void setOnprogress(final Function loadHandler) {
+        eventMapping_.put(Event.TYPE_PROGRESS, loadHandler);
+    }
+
+    /**
+     * Returns the event handler that fires on timeout.
+     * @return the event handler that fires on timeout
+     */
+    @JsxGetter
+    public Function getOntimeout() {
+        return getFunctionForEvent(Event.TYPE_TIMEOUT);
+    }
+
+    /**
+     * Sets the event handler that fires on timeout.
+     * @param loadHandler the event handler that fires on timeout
+     */
+    @JsxSetter
+    public void setOntimeout(final Function loadHandler) {
+        eventMapping_.put(Event.TYPE_TIMEOUT, loadHandler);
+    }
+
+    /**
+     * Returns the event handler that fires on timeout.
+     * @return the event handler that fires on timeout
+     */
+    @JsxGetter
+    public Function getOnreadystatechange() {
+        return getFunctionForEvent(Event.TYPE_READY_STATE_CHANGE);
+    }
+
+    /**
+     * Sets the event handler that fires on timeout.
+     * @param loadHandler the event handler that fires on timeout
+     */
+    @JsxSetter
+    public void setOnreadystatechange(final Function loadHandler) {
+        eventMapping_.put(Event.TYPE_READY_STATE_CHANGE, loadHandler);
+    }
+
+    /**
+     * Returns the event handler that fires on abort.
+     * @return the event handler that fires on abort
+     */
+    @JsxGetter
+    public Function getOnabort() {
+        return getFunctionForEvent(Event.TYPE_ABORT);
+    }
+
+    /**
+     * Sets the event handler that fires on abort.
+     * @param loadHandler the event handler that fires on abort
+     */
+    @JsxSetter
+    public void setOnabort(final Function loadHandler) {
+        eventMapping_.put(Event.TYPE_ABORT, loadHandler);
     }
 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest2Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest2Test.java
@@ -1082,4 +1082,39 @@ public class XMLHttpRequest2Test extends WebDriverTestCase {
 
         loadPageWithAlerts2(html);
     }
+
+    @Test
+    @Alerts("4")
+    public void onreadystatechange_eventListener() throws Exception {
+        final String html =
+              "<html>\n"
+            + "  <head>\n"
+            + "    <title>XMLHttpRequest Test</title>\n"
+            + "    <script>\n"
+            + "      var xhr;\n"
+            + "      function test() {\n"
+            + "        xhr = new XMLHttpRequest();\n"
+            + "        xhr.open('GET', '" + URL_SECOND + "', false);\n"
+            + "        xhr.addEventListener('readystatechange', onStateChange);\n"
+            + "        xhr.send('');\n"
+            + "      }\n"
+            + "      function onStateChange() {\n"
+            + "        alert(xhr.readyState);\n"
+            + "      }\n"
+            + "    </script>\n"
+            + "  </head>\n"
+            + "  <body onload='test()'>\n"
+            + "  </body>\n"
+            + "</html>";
+
+        final String xml =
+              "<xml>\n"
+            + "<content>blah</content>\n"
+            + "<content>blah2</content>\n"
+            + "</xml>";
+
+        getMockWebConnection().setResponse(URL_SECOND, xml, MimeType.TEXT_XML);
+        loadPageWithAlerts2(html);
+    }
+
 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest4Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest4Test.java
@@ -37,7 +37,7 @@ public class XMLHttpRequest4Test extends SimpleWebTestCase {
      * @throws Exception if the test fails
      */
     @Test
-    public void setLocation() throws Exception {
+    public void setLocation_onreadystatechange() throws Exception {
         final String content =
               "<html>\n"
             + "  <head>\n"
@@ -47,6 +47,37 @@ public class XMLHttpRequest4Test extends SimpleWebTestCase {
             + "      function testAsync() {\n"
             + "        request = new XMLHttpRequest();\n"
             + "        request.onreadystatechange = onReadyStateChange;\n"
+            + "        request.open('GET', 'foo.xml', true);\n"
+            + "        request.send('');\n"
+            + "      }\n"
+            + "      function onReadyStateChange() {\n"
+            + "        if (request.readyState == 4) {\n"
+            + "          window.location.href = 'about:blank';\n"
+            + "        }\n"
+            + "      }\n"
+            + "    </script>\n"
+            + "  </head>\n"
+            + "  <body onload='testAsync()'>\n"
+            + "  </body>\n"
+            + "</html>";
+
+        getMockWebConnection().setDefaultResponse("");
+        final WebWindow window = loadPage(content).getEnclosingWindow();
+        assertEquals(0, window.getWebClient().waitForBackgroundJavaScriptStartingBefore(1000));
+        assertEquals("about:blank", window.getEnclosedPage().getUrl());
+    }
+
+    @Test
+    public void setLocation_addEventListener() throws Exception {
+        final String content =
+              "<html>\n"
+            + "  <head>\n"
+            + "    <title>Page1</title>\n"
+            + "    <script>\n"
+            + "      var request;\n"
+            + "      function testAsync() {\n"
+            + "        request = new XMLHttpRequest();\n"
+            + "        request.addEventListener('readystatechange', onReadyStateChange);\n"
             + "        request.open('GET', 'foo.xml', true);\n"
             + "        request.send('');\n"
             + "      }\n"

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
@@ -31,11 +31,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriverException;
 
 import com.gargoylesoftware.htmlunit.BrowserRunner;
 import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
+import com.gargoylesoftware.htmlunit.BrowserRunner.NotYetImplemented;
 import com.gargoylesoftware.htmlunit.WebDriverTestCase;
 import com.gargoylesoftware.htmlunit.util.MimeType;
 
@@ -119,7 +122,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void addEventListener_lifeCycle_sync() throws Exception {
         //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
         loadPageWithAlerts2(buildHtml(Mode.SYNC, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
@@ -135,7 +138,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void addEventListener_lifeCycle_sync_Error500() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.ERROR_500, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
@@ -144,8 +147,16 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     @Test
     public void addEventListener_lifeCycle_sync_timeout() throws Exception {
         //that's invalid. You cannot set timeout for synced requests. Will throw an exception and not trigger any event.
-        loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.TIMEOUT, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
-                servlets_);
+        try {
+            loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.TIMEOUT, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
+                    servlets_);
+        }
+        catch (final WebDriverException e) {
+            if (useRealBrowser()) {
+                //we only expect the error to be thrown in htmlunit scenarios.
+                throw e;
+            }
+        }
     }
 
     /*
@@ -178,7 +189,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({ "readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true" })
+    @Alerts({"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true"})
     public void addEventListener_lifeCycle_async_readyStateChange() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.READY_STATE_CHANGE), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
@@ -194,7 +205,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("abort_false")
+    @Alerts("abort")
     public void addEventListener_lifeCycle_async_abortTriggered() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.SEND_ABORT, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
@@ -246,6 +257,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     @Test
     @Alerts("timeout_false")
+    @NotYetImplemented
     public void addEventListener_timeout_async_timeout() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
@@ -253,7 +265,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     //same tests as above, but this time we're triggering with the onkeyword.
     @Test
-    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void onKeyWord_lifeCycle_sync() throws Exception {
         //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
         loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
@@ -269,7 +281,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void onKeyWord_lifeCycle_sync_Error500() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.ERROR_500, State.values()), URL_FIRST,
                 DEFAULT_WAIT_TIME, servlets_);
@@ -278,8 +290,16 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     @Test
     public void onKeyWord_lifeCycle_sync_timeout() throws Exception {
         //that's invalid. You cannot set timeout for synced requests. Will throw an exception and not trigger any event.
-        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.TIMEOUT, State.values()), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        try {
+            loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.TIMEOUT, State.values()), URL_FIRST,
+                    DEFAULT_WAIT_TIME, servlets_);
+        }
+        catch (final WebDriverException e) {
+            if (useRealBrowser()) {
+                //we only expect the error to be thrown in htmlunit scenarios.
+                throw e;
+            }
+        }
     }
 
     @Test
@@ -308,7 +328,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({ "readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true" })
+    @Alerts({"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true"})
     public void onKeyWord_lifeCycle_async_readyStateChange() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.READY_STATE_CHANGE), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
@@ -325,7 +345,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("abort_false")
+    @Alerts("abort")
     public void onKeyWord_lifeCycle_async_abortTriggered() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.SEND_ABORT, State.ABORT), URL_FIRST,
                 DEFAULT_WAIT_TIME, servlets_);
@@ -377,9 +397,30 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     @Test
     @Alerts("timeout_false")
+    @NotYetImplemented
     public void onKeyWord_timeout_async_timeout() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST,
                 DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts({"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
+            "progress_false", "readystatechange_true", "load_false", "loadend_false"})
+    @Ignore("The tests are highly faulty because of the collecting of the alerts. We're swallowing some the alerts."
+            + "The test is still useful to check that the order of the events is correct.")
+    public void addEventListener_async_all_success() throws Exception {
+        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts({"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
+            "progress_false", "readystatechange_true", "load_false", "loadend_false"})
+    @Ignore("The tests are highly faulty because of the collecting of the alerts. We're swallowing some the alerts."
+            + "The test is still useful to check that the order of the events is correct.")
+    public void onKeyWord_async_all_success() throws Exception {
+        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     private String buildHtml(final Mode mode, final State... statesParam) {
@@ -402,9 +443,8 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         htmlBuilder.append("  <head>\n");
         htmlBuilder.append("    <title>XMLHttpRequest Test</title>\n");
         htmlBuilder.append("    <script>\n");
-        htmlBuilder.append("      var xhr;\n");
         htmlBuilder.append("      function test() {\n");
-        htmlBuilder.append("        xhr = new XMLHttpRequest();\n");
+        htmlBuilder.append("        var xhr = new XMLHttpRequest();\n");
         states.forEach(state -> registerEventListener(htmlBuilder, mode, state));
 
         htmlBuilder.append("        xhr.open('GET', '");
@@ -434,8 +474,8 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         htmlBuilder.append("      function alertEventState(event) {\n");
         htmlBuilder.append("        alert(event.type + '_' + (event.loaded === undefined));\n");
         htmlBuilder.append("      }\n");
-        htmlBuilder.append("      function alertIEAbortEventState(event) {\n");
-        htmlBuilder.append("        alert(event.type + '_0');\n");
+        htmlBuilder.append("      function alertAbort(event) {\n");
+        htmlBuilder.append("        alert(event.type);\n");
         htmlBuilder.append("      }\n");
         htmlBuilder.append("    </script>\n");
         htmlBuilder.append("  </head>\n");
@@ -447,12 +487,17 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     private void registerEventListener(final StringBuffer buffer, final Mode mode, final State state) {
+        String function = "alertEventState";
+        if (State.ABORT.equals(state)) {
+            function = "alertAbort";
+        }
+
         if (mode.isUseOnKeyword()) {
-            buffer.append("        xhr.on").append(state.getEventName_()).append("=alertEventState;\n");
+            buffer.append("        xhr.on").append(state.getEventName_()).append("=").append(function).append(";\n");
         }
         else {
-            buffer.append("        xhr.addEventListener('").append(state.getEventName_())
-                    .append("', alertEventState);\n");
+            buffer.append("        xhr.addEventListener('").append(state.getEventName_()).append("', ").append(function)
+                    .append(");\n");
         }
     }
 

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
@@ -132,7 +132,10 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("readystatechange_true")
+    @Alerts(DEFAULT = {"readystatechange_true", "ExceptionThrown"},
+            FF = {"readystatechange_true", "readystatechange_true", "error_false", "loadend_false", "ExceptionThrown"},
+            FF68 = {"readystatechange_true", "readystatechange_true", "error_false", "loadend_false",
+                    "ExceptionThrown"})
     public void addEventListener_lifeCycle_sync_networkError() throws Exception {
         // will throw an exception and user is supposed to handle this.
         // That's why we only have one readystatechange callback.
@@ -160,7 +163,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("readystatechange_true")
+    @Alerts({"readystatechange_true", "ExceptionThrown"})
     public void addEventListener_lifeCycle_sync_timeout() throws Exception {
         // that's invalid. You cannot set timeout for synced requests. Will throw an
         // exception only triggers readystatechange
@@ -177,11 +180,6 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
             verifyAlerts(() -> extractLog(getWebDriver()), String.join("\n", getExpectedAlerts()));
         }
     }
-
-    /*
-     * Testing the whole lifecycle of an async request
-     * we're doing this one by one since we're getting too many alerts to reliably determine the test outcome.
-     */
 
     @Test
     @Alerts("loadstart_false")
@@ -212,7 +210,10 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true"})
+    @Alerts(DEFAULT = {"readystatechange_true", "readystatechange_true", "readystatechange_true",
+            "readystatechange_true"},
+            IE = {"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true",
+                    "readystatechange_true"})
     public void addEventListener_lifeCycle_async_readyStateChange() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.READY_STATE_CHANGE), URL_FIRST, servlets_);
         verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
@@ -240,7 +241,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     @Test
     @Alerts("error_false")
-    public void addEventListener_lifeCycle_async_networkErrorTriggered() throws Exception {
+    public void addEventListener_lifeCycle_async_networkErrorTriggered_error() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.ERROR), URL_FIRST,
                 servlets_);
         verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
@@ -258,6 +259,17 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     @Alerts("loadend_false")
     public void addEventListener_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_END), URL_FIRST,
+                servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
+    }
+
+    @Test
+    @Alerts(DEFAULT = {"readystatechange_true", "loadstart_false", "readystatechange_true", "error_false",
+            "loadend_false"},
+            IE = {"readystatechange_true", "readystatechange_true", "loadstart_false", "readystatechange_true",
+                    "error_false", "loadend_false"})
+    public void addEventListener_lifeCycle_async_networkErrorTriggered() throws Exception {
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.values()), URL_FIRST,
                 servlets_);
         verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
@@ -308,7 +320,10 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("readystatechange_true")
+    @Alerts(DEFAULT = {"readystatechange_true", "ExceptionThrown"},
+            FF = {"readystatechange_true", "readystatechange_true", "error_false", "loadend_false", "ExceptionThrown"},
+            FF68 = {"readystatechange_true", "readystatechange_true", "error_false", "loadend_false",
+                    "ExceptionThrown"})
     public void onKeyWord_lifeCycle_sync_networkError() throws Exception {
         // will throw an exception and user is supposed to handle this.
         // That's why we only have one readystatechange callback.
@@ -324,7 +339,6 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         }
         finally {
             verifyAlerts(() -> extractLog(getWebDriver()), String.join("\n", getExpectedAlerts()));
-
         }
     }
 
@@ -337,22 +351,11 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("readystatechange_true")
+    @Alerts(DEFAULT = {"readystatechange_true", "ExceptionThrown"})
     public void onKeyWord_lifeCycle_sync_timeout() throws Exception {
-        // that's invalid. You cannot set timeout for synced requests. Will throw an
-        // exception and not trigger any event.
-        try {
-            loadPage2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.TIMEOUT, State.values()), URL_FIRST, servlets_);
-        }
-        catch (final WebDriverException e) {
-            if (useRealBrowser()) {
-                // we only expect the error to be thrown in htmlunit scenarios.
-                throw e;
-            }
-        }
-        finally {
-            verifyAlerts(() -> extractLog(getWebDriver()), String.join("\n", getExpectedAlerts()));
-        }
+        final WebDriver driver = loadPage2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.TIMEOUT, State.values()),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
@@ -384,7 +387,10 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true"})
+    @Alerts(DEFAULT = {"readystatechange_true", "readystatechange_true", "readystatechange_true",
+            "readystatechange_true"},
+            IE = {"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true",
+                    "readystatechange_true"})
     public void onKeyWord_lifeCycle_async_readyStateChange() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.READY_STATE_CHANGE), URL_FIRST,
                 servlets_);
@@ -413,7 +419,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     @Test
     @Alerts("error_false")
-    public void onKeyWord_lifeCycle_async_networkErrorTriggered() throws Exception {
+    public void onKeyWord_lifeCycle_async_networkErrorTriggered_error() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.ERROR),
                 URL_FIRST, servlets_);
         verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
@@ -431,6 +437,17 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     @Alerts("loadend_false")
     public void onKeyWord_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.LOAD_END),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
+    }
+
+    @Test
+    @Alerts(DEFAULT = {"readystatechange_true", "loadstart_false", "readystatechange_true", "error_false",
+            "loadend_false"},
+            IE = {"readystatechange_true", "readystatechange_true", "loadstart_false", "readystatechange_true",
+                    "error_false", "loadend_false"})
+    public void onKeyWord_lifeCycle_async_networkErrorTriggered() throws Exception {
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.values()),
                 URL_FIRST, servlets_);
         verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
@@ -471,16 +488,20 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts({"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
-            "progress_false", "readystatechange_true", "load_false", "loadend_false"})
+    @Alerts(DEFAULT = {"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
+            "progress_false", "readystatechange_true", "load_false", "loadend_false"},
+            IE = {"readystatechange_true", "readystatechange_true", "loadstart_false", "readystatechange_true",
+                    "readystatechange_true", "progress_false", "readystatechange_true", "load_false", "loadend_false"})
     public void addEventListener_async_all_success() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.values()), URL_FIRST, servlets_);
         verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
-    @Alerts({"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
-            "progress_false", "readystatechange_true", "load_false", "loadend_false"})
+    @Alerts(DEFAULT = {"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
+            "progress_false", "readystatechange_true", "load_false", "loadend_false"},
+            IE = {"readystatechange_true", "readystatechange_true", "loadstart_false", "readystatechange_true",
+                    "readystatechange_true", "progress_false", "readystatechange_true", "load_false", "loadend_false"})
     public void onKeyWord_async_all_success() throws Exception {
         final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.values()), URL_FIRST, servlets_);
         verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
@@ -530,21 +551,26 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         }
         htmlBuilder.append("', ").append(mode.isAsync()).append(");\n");
 
+        htmlBuilder.append("        try {\n");
+
         if (Execution.TIMEOUT.equals(execution)) {
             htmlBuilder.append("        xhr.timeout = 10;\n");
         }
 
-        htmlBuilder.append("        xhr.send();\n");
+        htmlBuilder.append("           xhr.send();\n");
         if (Execution.SEND_ABORT.equals(execution)) {
-            htmlBuilder.append("        xhr.abort();\n");
+            htmlBuilder.append("           xhr.abort();\n");
         }
+        htmlBuilder.append("        } catch (e) { logText('ExceptionThrown'); }\n");
         htmlBuilder.append("      }\n");
         htmlBuilder.append("      function alertEventState(event) {\n");
-        htmlBuilder.append("        document.getElementById('log').value += ");
-        htmlBuilder.append("           (event.type + '_' + (event.loaded === undefined)  + '\\n');\n");
+        htmlBuilder.append("        logText(event.type + '_' + (event.loaded === undefined));\n");
         htmlBuilder.append("      }\n");
         htmlBuilder.append("      function alertAbort(event) {\n");
-        htmlBuilder.append("        document.getElementById('log').value += event.type + '\\n';\n");
+        htmlBuilder.append("        logText(event.type);\n");
+        htmlBuilder.append("      }\n");
+        htmlBuilder.append("      function logText(txt) {\n");
+        htmlBuilder.append("        document.getElementById('log').value += txt + '\\n';\n");
         htmlBuilder.append("      }\n");
         htmlBuilder.append("    </script>\n");
         htmlBuilder.append("  </head>\n");

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
@@ -31,9 +31,10 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 
 import com.gargoylesoftware.htmlunit.BrowserRunner;
@@ -124,38 +125,56 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     @Test
     @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void addEventListener_lifeCycle_sync() throws Exception {
-        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
-        loadPageWithAlerts2(buildHtml(Mode.SYNC, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        // we can register ourselves for every state here since it's in sync mode and
+        // most of them won't fire anyway.
+        final WebDriver driver = loadPage2(buildHtml(Mode.SYNC, State.values()), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("readystatechange_true")
     public void addEventListener_lifeCycle_sync_networkError() throws Exception {
-        //will throw an exception and user is supposed to handle this.
-        //That's why we only have one readystatechange callback.
-        loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.NETWORK_ERROR, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
-                servlets_);
+        // will throw an exception and user is supposed to handle this.
+        // That's why we only have one readystatechange callback.
+        try {
+            loadPage2(buildHtml(Mode.SYNC, Execution.NETWORK_ERROR, State.values()), URL_FIRST, servlets_);
+        }
+        catch (final WebDriverException e) {
+            if (useRealBrowser()) {
+                // we only expect the error to be thrown in htmlunit scenarios.
+                throw e;
+            }
+        }
+        finally {
+            verifyAlerts(() -> extractLog(getWebDriver()), String.join("\n", getExpectedAlerts()));
+        }
+
     }
 
     @Test
     @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void addEventListener_lifeCycle_sync_Error500() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.ERROR_500, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.SYNC, Execution.ERROR_500, State.values()), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
+    @Alerts("readystatechange_true")
     public void addEventListener_lifeCycle_sync_timeout() throws Exception {
-        //that's invalid. You cannot set timeout for synced requests. Will throw an exception and not trigger any event.
+        // that's invalid. You cannot set timeout for synced requests. Will throw an
+        // exception only triggers readystatechange
         try {
-            loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.TIMEOUT, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
-                    servlets_);
+            loadPage2(buildHtml(Mode.SYNC, Execution.TIMEOUT, State.values()), URL_FIRST, servlets_);
         }
         catch (final WebDriverException e) {
             if (useRealBrowser()) {
-                //we only expect the error to be thrown in htmlunit scenarios.
+                // we only expect the error to be thrown in htmlunit scenarios.
                 throw e;
             }
+        }
+        finally {
+            verifyAlerts(() -> extractLog(getWebDriver()), String.join("\n", getExpectedAlerts()));
         }
     }
 
@@ -167,69 +186,80 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     @Test
     @Alerts("loadstart_false")
     public void addEventListener_lifeCycle_async_loadStart() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.LOAD_START), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("load_false")
     public void addEventListener_lifeCycle_async_load() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.LOAD), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadend_false")
     public void addEventListener_lifeCycle_async_loadEnd() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.LOAD_END), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("progress_false")
     public void addEventListener_lifeCycle_async_progress() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.PROGRESS), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.PROGRESS), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts({"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true"})
     public void addEventListener_lifeCycle_async_readyStateChange() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.READY_STATE_CHANGE), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.READY_STATE_CHANGE), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     public void addEventListener_lifeCycle_async_error() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.ERROR), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     public void addEventListener_lifeCycle_async_noAbort() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.ABORT), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("abort")
     public void addEventListener_lifeCycle_async_abortTriggered() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.SEND_ABORT, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.SEND_ABORT, State.ABORT), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("error_false")
     public void addEventListener_lifeCycle_async_networkErrorTriggered() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.ERROR), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadstart_false")
     public void addEventListener_lifeCycle_async_networkErrorTriggered_loadStart() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_START), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_START), URL_FIRST,
+                servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadend_false")
     public void addEventListener_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_END), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_END), URL_FIRST,
+                servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     /**
@@ -237,139 +267,172 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
      */
     @Test
     public void addEventListener_lifeCycle_async_Error500Triggered() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.ERROR_500, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.ERROR_500, State.ERROR), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadstart_false")
     public void addEventListener_timeout_async_loadStart() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_START), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadend_false")
     public void addEventListener_timeout_async_loadEnd() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_END), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("timeout_false")
     @NotYetImplemented
     public void addEventListener_timeout_async_timeout() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
-    //same tests as above, but this time we're triggering with the onkeyword.
+    // same tests as above, but this time we're triggering with the onkeyword.
     @Test
     @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void onKeyWord_lifeCycle_sync() throws Exception {
-        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
-        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        // we can register ourselves for every state here since it's in sync mode and
+        // most of them won't fire anyway.
+        final WebDriver driver = loadPage2(buildHtml(Mode.SYNC_ON_KEYWORD, State.values()), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("readystatechange_true")
     public void onKeyWord_lifeCycle_sync_networkError() throws Exception {
-        //will throw an exception and user is supposed to handle this.
-        //That's why we only have one readystatechange callback.
-        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.values()), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        // will throw an exception and user is supposed to handle this.
+        // That's why we only have one readystatechange callback.
+        try {
+            loadPage2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.values()), URL_FIRST, servlets_);
+
+        }
+        catch (final WebDriverException e) {
+            if (useRealBrowser()) {
+                // we only expect the error to be thrown in htmlunit scenarios.
+                throw e;
+            }
+        }
+        finally {
+            verifyAlerts(() -> extractLog(getWebDriver()), String.join("\n", getExpectedAlerts()));
+
+        }
     }
 
     @Test
     @Alerts({"readystatechange_true", "readystatechange_true", "load_false", "loadend_false"})
     public void onKeyWord_lifeCycle_sync_Error500() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.ERROR_500, State.values()), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.ERROR_500, State.values()),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
+    @Alerts("readystatechange_true")
     public void onKeyWord_lifeCycle_sync_timeout() throws Exception {
-        //that's invalid. You cannot set timeout for synced requests. Will throw an exception and not trigger any event.
+        // that's invalid. You cannot set timeout for synced requests. Will throw an
+        // exception and not trigger any event.
         try {
-            loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.TIMEOUT, State.values()), URL_FIRST,
-                    DEFAULT_WAIT_TIME, servlets_);
+            loadPage2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.TIMEOUT, State.values()), URL_FIRST, servlets_);
         }
         catch (final WebDriverException e) {
             if (useRealBrowser()) {
-                //we only expect the error to be thrown in htmlunit scenarios.
+                // we only expect the error to be thrown in htmlunit scenarios.
                 throw e;
             }
+        }
+        finally {
+            verifyAlerts(() -> extractLog(getWebDriver()), String.join("\n", getExpectedAlerts()));
         }
     }
 
     @Test
     @Alerts("loadstart_false")
     public void onKeyWord_lifeCycle_async_loadStart() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME,
-                servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD_START), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("load_false")
     public void onKeyWord_lifeCycle_async_load() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadend_false")
     public void onKeyWord_lifeCycle_async_loadEnd() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD_END), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("progress_false")
     public void onKeyWord_lifeCycle_async_progress() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.PROGRESS), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.PROGRESS), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts({"readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true"})
     public void onKeyWord_lifeCycle_async_readyStateChange() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.READY_STATE_CHANGE), URL_FIRST, DEFAULT_WAIT_TIME,
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.READY_STATE_CHANGE), URL_FIRST,
                 servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     public void onKeyWord_lifeCycle_async_error() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.ERROR), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     public void onKeyWord_lifeCycle_async_noAbort() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.ABORT), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("abort")
     public void onKeyWord_lifeCycle_async_abortTriggered() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.SEND_ABORT, State.ABORT), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.SEND_ABORT, State.ABORT),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("error_false")
     public void onKeyWord_lifeCycle_async_networkErrorTriggered() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.ERROR), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.ERROR),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadstart_false")
     public void onKeyWord_lifeCycle_async_networkErrorTriggered_loadStart() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.LOAD_START), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.LOAD_START),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadend_false")
     public void onKeyWord_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.LOAD_END), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.LOAD_END),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     /**
@@ -377,54 +440,58 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
      */
     @Test
     public void onKeyWord_lifeCycle_async_Error500Triggered() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.ERROR_500, State.ERROR), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.ERROR_500, State.ERROR),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadstart_false")
     public void onKeyWord_timeout_async_loadStart() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.LOAD_START), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.LOAD_START),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("loadend_false")
     public void onKeyWord_timeout_async_loadEnd() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.LOAD_END), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.LOAD_END),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts("timeout_false")
     @NotYetImplemented
     public void onKeyWord_timeout_async_timeout() throws Exception {
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST,
-                DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.TIMEOUT),
+                URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts({"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
             "progress_false", "readystatechange_true", "load_false", "loadend_false"})
-    @Ignore("The tests are highly faulty because of the collecting of the alerts. We're swallowing some the alerts."
-            + "The test is still useful to check that the order of the events is correct.")
     public void addEventListener_async_all_success() throws Exception {
-        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC, State.values()), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     @Test
     @Alerts({"readystatechange_true", "loadstart_false", "readystatechange_true", "readystatechange_true",
             "progress_false", "readystatechange_true", "load_false", "loadend_false"})
-    @Ignore("The tests are highly faulty because of the collecting of the alerts. We're swallowing some the alerts."
-            + "The test is still useful to check that the order of the events is correct.")
     public void onKeyWord_async_all_success() throws Exception {
-        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
-        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+        final WebDriver driver = loadPage2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.values()), URL_FIRST, servlets_);
+        verifyAlerts(() -> extractLog(driver), String.join("\n", getExpectedAlerts()));
     }
 
     private String buildHtml(final Mode mode, final State... statesParam) {
         return buildHtml(mode, Execution.ONLY_SEND, statesParam);
+    }
+
+    private String extractLog(final WebDriver driver) {
+        return driver.findElement(By.id("log")).getAttribute("value").trim().replaceAll("\r", "");
     }
 
     /**
@@ -444,6 +511,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         htmlBuilder.append("    <title>XMLHttpRequest Test</title>\n");
         htmlBuilder.append("    <script>\n");
         htmlBuilder.append("      function test() {\n");
+        htmlBuilder.append("        document.getElementById('log').value = '';");
         htmlBuilder.append("        var xhr = new XMLHttpRequest();\n");
         states.forEach(state -> registerEventListener(htmlBuilder, mode, state));
 
@@ -472,14 +540,16 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         }
         htmlBuilder.append("      }\n");
         htmlBuilder.append("      function alertEventState(event) {\n");
-        htmlBuilder.append("        alert(event.type + '_' + (event.loaded === undefined));\n");
+        htmlBuilder.append("        document.getElementById('log').value += ");
+        htmlBuilder.append("           (event.type + '_' + (event.loaded === undefined)  + '\\n');\n");
         htmlBuilder.append("      }\n");
         htmlBuilder.append("      function alertAbort(event) {\n");
-        htmlBuilder.append("        alert(event.type);\n");
+        htmlBuilder.append("        document.getElementById('log').value += event.type + '\\n';\n");
         htmlBuilder.append("      }\n");
         htmlBuilder.append("    </script>\n");
         htmlBuilder.append("  </head>\n");
         htmlBuilder.append("  <body onload='test()'>\n");
+        htmlBuilder.append("    <textarea id='log' cols='80' rows='40'></textarea>\n");
         htmlBuilder.append("  </body>\n");
         htmlBuilder.append("</html>");
 
@@ -547,7 +617,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
                 writer.write(RETURN_XML);
             }
             catch (final Exception e) {
-                //ignored.
+                // ignored.
             }
         }
     }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
@@ -71,11 +71,40 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
     private final Map<String, Class<? extends Servlet>> servlets_ = new HashMap<>();
 
     private enum State {
-        LOAD_START, LOAD, LOAD_END, PROGRESS, ERROR, ABORT, READY_STATE_CHANGE, TIMEOUT
+        LOAD_START("loadstart"), LOAD("load"), LOAD_END("loadend"), PROGRESS("progress"), ERROR("error"),
+        ABORT("abort"), READY_STATE_CHANGE("readystatechange"), TIMEOUT("timeout");
+
+        private final String eventName_;
+
+        State(final String eventName) {
+            eventName_ = eventName;
+        }
+
+        public String getEventName_() {
+            return eventName_;
+        }
+
     }
 
     private enum Mode {
-        ASYNC, SYNC
+        ASYNC(true, false), SYNC(false, false), ASYNC_ON_KEYWORD(true, true), SYNC_ON_KEYWORD(false, true);
+
+        private final boolean async_;
+        private final boolean useOnKeyword_;
+
+        Mode(final boolean async, final boolean useOnKeyword) {
+            async_ = async;
+            useOnKeyword_ = useOnKeyword;
+        }
+
+        public boolean isAsync() {
+            return async_;
+        }
+
+        public boolean isUseOnKeyword() {
+            return useOnKeyword_;
+        }
+
     }
 
     private enum Execution {
@@ -91,14 +120,14 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     @Test
     @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
-    public void stateChange_lifeCycle_sync() throws Exception {
+    public void addEventListener_lifeCycle_sync() throws Exception {
         //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
         loadPageWithAlerts2(buildHtml(Mode.SYNC, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
     @Alerts("readystatechange_true")
-    public void stateChange_lifeCycle_sync_networkError() throws Exception {
+    public void addEventListener_lifeCycle_sync_networkError() throws Exception {
         //will throw an exception and user is supposed to handle this.
         //That's why we only have one readystatechange callback.
         loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.NETWORK_ERROR, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
@@ -107,13 +136,13 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     @Test
     @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
-    public void stateChange_lifeCycle_sync_Error500() throws Exception {
+    public void addEventListener_lifeCycle_sync_Error500() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.ERROR_500, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
     }
 
     @Test
-    public void stateChange_lifeCycle_sync_timeout() throws Exception {
+    public void addEventListener_lifeCycle_sync_timeout() throws Exception {
         //that's invalid. You cannot set timeout for synced requests. Will throw an exception and not trigger any event.
         loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.TIMEOUT, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
@@ -126,68 +155,68 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
 
     @Test
     @Alerts("loadstart_false")
-    public void stateChange_lifeCycle_async_loadStart() throws Exception {
+    public void addEventListener_lifeCycle_async_loadStart() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
     @Alerts("load_false")
-    public void stateChange_lifeCycle_async_load() throws Exception {
+    public void addEventListener_lifeCycle_async_load() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
     @Alerts("loadend_false")
-    public void stateChange_lifeCycle_async_loadEnd() throws Exception {
+    public void addEventListener_lifeCycle_async_loadEnd() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
     @Alerts("progress_false")
-    public void stateChange_lifeCycle_async_progress() throws Exception {
+    public void addEventListener_lifeCycle_async_progress() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.PROGRESS), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
     @Alerts({ "readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true" })
-    public void stateChange_lifeCycle_async_readyStateChange() throws Exception {
+    public void addEventListener_lifeCycle_async_readyStateChange() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.READY_STATE_CHANGE), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
-    public void stateChange_lifeCycle_async_error() throws Exception {
+    public void addEventListener_lifeCycle_async_error() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
-    public void stateChange_lifeCycle_async_noAbort() throws Exception {
+    public void addEventListener_lifeCycle_async_noAbort() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
     @Alerts("abort_false")
-    public void stateChange_lifeCycle_async_abortTriggered() throws Exception {
+    public void addEventListener_lifeCycle_async_abortTriggered() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.SEND_ABORT, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
     }
 
     @Test
     @Alerts("error_false")
-    public void stateChange_lifeCycle_async_networkErrorTriggered() throws Exception {
+    public void addEventListener_lifeCycle_async_networkErrorTriggered() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
     }
 
     @Test
     @Alerts("loadstart_false")
-    public void stateChange_lifeCycle_async_networkErrorTriggered_loadStart() throws Exception {
+    public void addEventListener_lifeCycle_async_networkErrorTriggered_loadStart() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_START), URL_FIRST,
                 DEFAULT_WAIT_TIME, servlets_);
     }
 
     @Test
     @Alerts("loadend_false")
-    public void stateChange_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
+    public void addEventListener_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_END), URL_FIRST,
                 DEFAULT_WAIT_TIME, servlets_);
     }
@@ -196,30 +225,161 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
      * Error 500 on the server side still count as a valid requests for {@link XMLHttpRequest}.
      */
     @Test
-    public void stateChange_lifeCycle_async_Error500Triggered() throws Exception {
+    public void addEventListener_lifeCycle_async_Error500Triggered() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.ERROR_500, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
     }
 
     @Test
     @Alerts("loadstart_false")
-    public void stateChange_timeout_async_loadStart() throws Exception {
+    public void addEventListener_timeout_async_loadStart() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
     }
 
     @Test
     @Alerts("loadend_false")
-    public void stateChange_timeout_async_loadEnd() throws Exception {
+    public void addEventListener_timeout_async_loadEnd() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
     }
 
     @Test
     @Alerts("timeout_false")
-    public void stateChange_timeout_async_timeout() throws Exception {
+    public void addEventListener_timeout_async_timeout() throws Exception {
         loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST, DEFAULT_WAIT_TIME,
                 servlets_);
+    }
+
+    //same tests as above, but this time we're triggering with the onkeyword.
+    @Test
+    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    public void onKeyWord_lifeCycle_sync() throws Exception {
+        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
+        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("readystatechange_true")
+    public void onKeyWord_lifeCycle_sync_networkError() throws Exception {
+        //will throw an exception and user is supposed to handle this.
+        //That's why we only have one readystatechange callback.
+        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.values()), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    public void onKeyWord_lifeCycle_sync_Error500() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.ERROR_500, State.values()), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    public void onKeyWord_lifeCycle_sync_timeout() throws Exception {
+        //that's invalid. You cannot set timeout for synced requests. Will throw an exception and not trigger any event.
+        loadPageWithAlerts2(buildHtml(Mode.SYNC_ON_KEYWORD, Execution.TIMEOUT, State.values()), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadstart_false")
+    public void onKeyWord_lifeCycle_async_loadStart() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    @Alerts("load_false")
+    public void onKeyWord_lifeCycle_async_load() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadend_false")
+    public void onKeyWord_lifeCycle_async_loadEnd() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("progress_false")
+    public void onKeyWord_lifeCycle_async_progress() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.PROGRESS), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts({ "readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true" })
+    public void onKeyWord_lifeCycle_async_readyStateChange() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.READY_STATE_CHANGE), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    public void onKeyWord_lifeCycle_async_error() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    public void onKeyWord_lifeCycle_async_noAbort() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("abort_false")
+    public void onKeyWord_lifeCycle_async_abortTriggered() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.SEND_ABORT, State.ABORT), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("error_false")
+    public void onKeyWord_lifeCycle_async_networkErrorTriggered() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.ERROR), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadstart_false")
+    public void onKeyWord_lifeCycle_async_networkErrorTriggered_loadStart() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.LOAD_START), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadend_false")
+    public void onKeyWord_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.NETWORK_ERROR, State.LOAD_END), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    /**
+     * Error 500 on the server side still count as a valid requests for {@link XMLHttpRequest}.
+     */
+    @Test
+    public void onKeyWord_lifeCycle_async_Error500Triggered() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.ERROR_500, State.ERROR), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadstart_false")
+    public void onKeyWord_timeout_async_loadStart() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.LOAD_START), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadend_false")
+    public void onKeyWord_timeout_async_loadEnd() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.LOAD_END), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("timeout_false")
+    public void onKeyWord_timeout_async_timeout() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC_ON_KEYWORD, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
     }
 
     private String buildHtml(final Mode mode, final State... statesParam) {
@@ -245,30 +405,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         htmlBuilder.append("      var xhr;\n");
         htmlBuilder.append("      function test() {\n");
         htmlBuilder.append("        xhr = new XMLHttpRequest();\n");
-        if (states.contains(State.LOAD_START)) {
-            htmlBuilder.append("        xhr.addEventListener('loadstart', alertEventState);\n");
-        }
-        if (states.contains(State.LOAD)) {
-            htmlBuilder.append("        xhr.addEventListener('load', alertEventState);\n");
-        }
-        if (states.contains(State.LOAD_END)) {
-            htmlBuilder.append("        xhr.addEventListener('loadend', alertEventState);\n");
-        }
-        if (states.contains(State.PROGRESS)) {
-            htmlBuilder.append("        xhr.addEventListener('progress', alertEventState);\n");
-        }
-        if (states.contains(State.ERROR)) {
-            htmlBuilder.append("        xhr.addEventListener('error', alertEventState);\n");
-        }
-        if (states.contains(State.ABORT)) {
-            htmlBuilder.append("        xhr.addEventListener('abort', alertEventState);\n");
-        }
-        if (states.contains(State.READY_STATE_CHANGE)) {
-            htmlBuilder.append("        xhr.addEventListener('readystatechange', alertEventState);\n");
-        }
-        if (states.contains(State.TIMEOUT)) {
-            htmlBuilder.append("        xhr.addEventListener('timeout', alertEventState);\n");
-        }
+        states.forEach(state -> registerEventListener(htmlBuilder, mode, state));
 
         htmlBuilder.append("        xhr.open('GET', '");
         if (Execution.NETWORK_ERROR.equals(execution)) {
@@ -283,7 +420,7 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         else {
             htmlBuilder.append(SUCCESS_URL);
         }
-        htmlBuilder.append("', ").append(Mode.ASYNC.equals(mode)).append(");\n");
+        htmlBuilder.append("', ").append(mode.isAsync()).append(");\n");
 
         if (Execution.TIMEOUT.equals(execution)) {
             htmlBuilder.append("        xhr.timeout = 10;\n");
@@ -307,6 +444,16 @@ public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
         htmlBuilder.append("</html>");
 
         return htmlBuilder.toString();
+    }
+
+    private void registerEventListener(final StringBuffer buffer, final Mode mode, final State state) {
+        if (mode.isUseOnKeyword()) {
+            buffer.append("        xhr.on").append(state.getEventName_()).append("=alertEventState;\n");
+        }
+        else {
+            buffer.append("        xhr.addEventListener('").append(state.getEventName_())
+                    .append("', alertEventState);\n");
+        }
     }
 
     public static class Xml200Servlet extends HttpServlet {

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XmlHttpRequestLifeCycleTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2002-2020 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gargoylesoftware.htmlunit.javascript.host.xml;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.BrowserRunner;
+import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
+import com.gargoylesoftware.htmlunit.WebDriverTestCase;
+import com.gargoylesoftware.htmlunit.util.MimeType;
+
+/**
+ * Tests for the LifeCycle events for XMLHttpRequests.
+ * readystatechange
+ * loadstart - whenever the loading is started. will always have a payload of 0.
+ * loadend - whenever the loading is finished. Will be triggered after error as well.
+ * progress - periodic updates that the transfer is still in progress. will only be triggered in async requests.
+ * abort - aborts the scheduled request. will only be triggerd in async requests.
+ * error - on network errors. server status will be ignored for this.
+ * timeout - when the request is terminated because of the timeout
+ * (only available in async requests, otherwise xhr.send will fail)
+ *
+ * The tests are split between sync (full-event cycle test) and async (each event is tested on it's own).
+ * This is mainly done because we cannot reliably handle the amount & speed of the alerts if everything is
+ * executed together (Chrome did work in tests, FF & IE did not).
+ *
+ * @author Thorsten Wendelmuth
+ *
+ */
+@RunWith(BrowserRunner.class)
+public class XmlHttpRequestLifeCycleTest extends WebDriverTestCase {
+    private static final String SUCCESS_URL = "/xmlhttprequest/success.html";
+    private static final String ERROR_URL = "/xmlhttprequest/error.html";
+    private static final String TIMEOUT_URL = "/xmlhttprequest/timeout.html";
+
+    private static final String RETURN_XML = "<xml>\n"
+            + "<content>htmlunit</content>\n"
+            + "<content>xmlhttpRequest</content>\n"
+            + "</xml>";
+
+    private final Map<String, Class<? extends Servlet>> servlets_ = new HashMap<>();
+
+    private enum State {
+        LOAD_START, LOAD, LOAD_END, PROGRESS, ERROR, ABORT, READY_STATE_CHANGE, TIMEOUT
+    }
+
+    private enum Mode {
+        ASYNC, SYNC
+    }
+
+    private enum Execution {
+        ONLY_SEND, SEND_ABORT, NETWORK_ERROR, ERROR_500, TIMEOUT
+    }
+
+    @Before
+    public void prepareTestingServlets() {
+        servlets_.put(SUCCESS_URL, Xml200Servlet.class);
+        servlets_.put(ERROR_URL, Xml500Servlet.class);
+        servlets_.put(TIMEOUT_URL, XmlTimeoutServlet.class);
+    }
+
+    @Test
+    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    public void stateChange_lifeCycle_sync() throws Exception {
+        //we can register ourselves for every state here since it's in sync mode and most of them won't fire anyway.
+        loadPageWithAlerts2(buildHtml(Mode.SYNC, State.values()), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("readystatechange_true")
+    public void stateChange_lifeCycle_sync_networkError() throws Exception {
+        //will throw an exception and user is supposed to handle this.
+        //That's why we only have one readystatechange callback.
+        loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.NETWORK_ERROR, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    @Alerts({ "readystatechange_true", "readystatechange_true", "load_false", "loadend_false" })
+    public void stateChange_lifeCycle_sync_Error500() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.ERROR_500, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    public void stateChange_lifeCycle_sync_timeout() throws Exception {
+        //that's invalid. You cannot set timeout for synced requests. Will throw an exception and not trigger any event.
+        loadPageWithAlerts2(buildHtml(Mode.SYNC, Execution.TIMEOUT, State.values()), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    /*
+     * Testing the whole lifecycle of an async request
+     * we're doing this one by one since we're getting too many alerts to reliably determine the test outcome.
+     */
+
+    @Test
+    @Alerts("loadstart_false")
+    public void stateChange_lifeCycle_async_loadStart() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("load_false")
+    public void stateChange_lifeCycle_async_load() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadend_false")
+    public void stateChange_lifeCycle_async_loadEnd() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("progress_false")
+    public void stateChange_lifeCycle_async_progress() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.PROGRESS), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts({ "readystatechange_true", "readystatechange_true", "readystatechange_true", "readystatechange_true" })
+    public void stateChange_lifeCycle_async_readyStateChange() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.READY_STATE_CHANGE), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    public void stateChange_lifeCycle_async_error() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    public void stateChange_lifeCycle_async_noAbort() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("abort_false")
+    public void stateChange_lifeCycle_async_abortTriggered() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.SEND_ABORT, State.ABORT), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    @Alerts("error_false")
+    public void stateChange_lifeCycle_async_networkErrorTriggered() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    @Alerts("loadstart_false")
+    public void stateChange_lifeCycle_async_networkErrorTriggered_loadStart() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_START), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    @Test
+    @Alerts("loadend_false")
+    public void stateChange_lifeCycle_async_networkErrorTriggered_loadEnd() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.NETWORK_ERROR, State.LOAD_END), URL_FIRST,
+                DEFAULT_WAIT_TIME, servlets_);
+    }
+
+    /**
+     * Error 500 on the server side still count as a valid requests for {@link XMLHttpRequest}.
+     */
+    @Test
+    public void stateChange_lifeCycle_async_Error500Triggered() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.ERROR_500, State.ERROR), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    @Alerts("loadstart_false")
+    public void stateChange_timeout_async_loadStart() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_START), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    @Alerts("loadend_false")
+    public void stateChange_timeout_async_loadEnd() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.LOAD_END), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    @Test
+    @Alerts("timeout_false")
+    public void stateChange_timeout_async_timeout() throws Exception {
+        loadPageWithAlerts2(buildHtml(Mode.ASYNC, Execution.TIMEOUT, State.TIMEOUT), URL_FIRST, DEFAULT_WAIT_TIME,
+                servlets_);
+    }
+
+    private String buildHtml(final Mode mode, final State... statesParam) {
+        return buildHtml(mode, Execution.ONLY_SEND, statesParam);
+    }
+
+    /**
+     * Alerts each State that has been triggered in the form of:
+     * event.type_(isUndefined?)
+     * @param mode
+     * @param execution
+     * @param statesParam
+     * @return
+     */
+    private String buildHtml(final Mode mode, final Execution execution, final State... statesParam) {
+        final List<State> states = Arrays.asList(statesParam);
+
+        final StringBuffer htmlBuilder = new StringBuffer();
+        htmlBuilder.append("<html>\n");
+        htmlBuilder.append("  <head>\n");
+        htmlBuilder.append("    <title>XMLHttpRequest Test</title>\n");
+        htmlBuilder.append("    <script>\n");
+        htmlBuilder.append("      var xhr;\n");
+        htmlBuilder.append("      function test() {\n");
+        htmlBuilder.append("        xhr = new XMLHttpRequest();\n");
+        if (states.contains(State.LOAD_START)) {
+            htmlBuilder.append("        xhr.addEventListener('loadstart', alertEventState);\n");
+        }
+        if (states.contains(State.LOAD)) {
+            htmlBuilder.append("        xhr.addEventListener('load', alertEventState);\n");
+        }
+        if (states.contains(State.LOAD_END)) {
+            htmlBuilder.append("        xhr.addEventListener('loadend', alertEventState);\n");
+        }
+        if (states.contains(State.PROGRESS)) {
+            htmlBuilder.append("        xhr.addEventListener('progress', alertEventState);\n");
+        }
+        if (states.contains(State.ERROR)) {
+            htmlBuilder.append("        xhr.addEventListener('error', alertEventState);\n");
+        }
+        if (states.contains(State.ABORT)) {
+            htmlBuilder.append("        xhr.addEventListener('abort', alertEventState);\n");
+        }
+        if (states.contains(State.READY_STATE_CHANGE)) {
+            htmlBuilder.append("        xhr.addEventListener('readystatechange', alertEventState);\n");
+        }
+        if (states.contains(State.TIMEOUT)) {
+            htmlBuilder.append("        xhr.addEventListener('timeout', alertEventState);\n");
+        }
+
+        htmlBuilder.append("        xhr.open('GET', '");
+        if (Execution.NETWORK_ERROR.equals(execution)) {
+            htmlBuilder.append((URL_FIRST + SUCCESS_URL).replace("http://", "https://"));
+        }
+        else if (Execution.ERROR_500.equals(execution)) {
+            htmlBuilder.append(ERROR_URL);
+        }
+        else if (Execution.TIMEOUT.equals(execution)) {
+            htmlBuilder.append(TIMEOUT_URL);
+        }
+        else {
+            htmlBuilder.append(SUCCESS_URL);
+        }
+        htmlBuilder.append("', ").append(Mode.ASYNC.equals(mode)).append(");\n");
+
+        if (Execution.TIMEOUT.equals(execution)) {
+            htmlBuilder.append("        xhr.timeout = 10;\n");
+        }
+
+        htmlBuilder.append("        xhr.send();\n");
+        if (Execution.SEND_ABORT.equals(execution)) {
+            htmlBuilder.append("        xhr.abort();\n");
+        }
+        htmlBuilder.append("      }\n");
+        htmlBuilder.append("      function alertEventState(event) {\n");
+        htmlBuilder.append("        alert(event.type + '_' + (event.loaded === undefined));\n");
+        htmlBuilder.append("      }\n");
+        htmlBuilder.append("      function alertIEAbortEventState(event) {\n");
+        htmlBuilder.append("        alert(event.type + '_0');\n");
+        htmlBuilder.append("      }\n");
+        htmlBuilder.append("    </script>\n");
+        htmlBuilder.append("  </head>\n");
+        htmlBuilder.append("  <body onload='test()'>\n");
+        htmlBuilder.append("  </body>\n");
+        htmlBuilder.append("</html>");
+
+        return htmlBuilder.toString();
+    }
+
+    public static class Xml200Servlet extends HttpServlet {
+
+        @Override
+        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+                throws ServletException, IOException {
+            resp.setContentType(MimeType.TEXT_XML);
+            resp.setContentLength(RETURN_XML.length());
+            resp.setStatus(HttpStatus.SC_OK);
+            final ServletOutputStream outputStream = resp.getOutputStream();
+            try (Writer writer = new OutputStreamWriter(outputStream)) {
+                writer.write(RETURN_XML);
+            }
+
+        }
+    }
+
+    public static class Xml500Servlet extends HttpServlet {
+
+        @Override
+        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+                throws ServletException, IOException {
+            resp.setContentType(MimeType.TEXT_XML);
+            resp.setContentLength(RETURN_XML.length());
+            resp.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            final ServletOutputStream outputStream = resp.getOutputStream();
+            try (Writer writer = new OutputStreamWriter(outputStream)) {
+                writer.write(RETURN_XML);
+            }
+        }
+    }
+
+    public static class XmlTimeoutServlet extends HttpServlet {
+
+        @Override
+        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+                throws ServletException, IOException {
+            resp.setContentType(MimeType.TEXT_XML);
+            resp.setContentLength(RETURN_XML.length());
+            resp.setStatus(HttpStatus.SC_OK);
+            final ServletOutputStream outputStream = resp.getOutputStream();
+            try (Writer writer = new OutputStreamWriter(outputStream)) {
+                writer.flush();
+                Thread.sleep(500);
+                writer.write(RETURN_XML);
+            }
+            catch (final Exception e) {
+                //ignored.
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
…dEventListener

So far we're only triggering event on state change if you're using `xhr.onreadystatechange = function()` and ignoring any `readystatechange` events added to the eventlisteners.