### PR TITLE
Avoid rendering script just for the description

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/ScriptElementSupport.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/ScriptElementSupport.java
@@ -77,7 +77,8 @@ public final class ScriptElementSupport {
             LOG.debug("Script node added: " + element.asXml());
         }
 
-        final PostponedAction action = new PostponedAction(element.getPage(), "Execution of script " + element) {
+        final String description = "Execution of " + element.getClass().getSimpleName();
+        final PostponedAction action = new PostponedAction(element.getPage(), description) {
             @Override
             public void execute() {
                 final HTMLDocument jsDoc = (HTMLDocument)


### PR DESCRIPTION
This was a major performance issue. See #277.

Maybe there is a better description for the action than the script class?