### PR TITLE
Avoid rendering the whole script just for the description

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/ScriptElementSupport.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/ScriptElementSupport.java
@@ -91,7 +91,8 @@ public final class ScriptElementSupport {
 
         final WebWindow webWindow = element.getPage().getEnclosingWindow();
         if (webWindow != null) {
-            final PostponedAction action = new PostponedAction(element.getPage(), "Execution of script " + element) {
+            final String description = "Execution of " + element.getClass().getSimpleName();
+            final PostponedAction action = new PostponedAction(element.getPage(), description) {
                 @Override
                 public void execute() {
                     // see HTMLDocument.setExecutingDynamicExternalPosponed(boolean)


### PR DESCRIPTION
This was a major performance issue. See #277.

Maybe there is a better description than the script class name?