### PR TITLE
XMLHttpRequest: Change to more consistent event invocation order

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest.java
@@ -221,28 +221,7 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
             event = progressEvent;
         }
 
-        final JavaScriptEngine jsEngine = (JavaScriptEngine) containingPage_.getWebClient().getJavaScriptEngine();
-        final Function onFunction = getFunctionForEvent(eventName);
-        if (onFunction != null) {
-            jsEngine.callFunction(containingPage_, onFunction, onFunction.getParentScope(), this,
-                    new Object[]{event});
-        }
-
-        triggerJavascriptHandlers(jsEngine, getEventListenersContainer().getListeners(eventName, false), event);
-        triggerJavascriptHandlers(jsEngine, getEventListenersContainer().getListeners(eventName, true), event);
-    }
-
-    private void triggerJavascriptHandlers(final JavaScriptEngine jsEngine, final List<Scriptable> handlers,
-            final Event event) {
-        if (handlers != null) {
-            final Object[] parameter = {event};
-            for (final Scriptable scriptable : handlers) {
-                if (scriptable instanceof Function) {
-                    final Function function = (Function) scriptable;
-                    jsEngine.callFunction(containingPage_, function, function.getParentScope(), this, parameter);
-                }
-            }
-        }
+        executeEventLocally(event);
     }
 
     /**

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequestEventTarget.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequestEventTarget.java
@@ -19,9 +19,6 @@ import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBr
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF78;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxConstructor;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxGetter;
@@ -42,8 +39,6 @@ import net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime;
 @JsxClass
 public class XMLHttpRequestEventTarget extends EventTarget {
 
-    private final Map<String, Function> eventMapping_ = new HashMap<>();
-
     /**
      * Creates an instance.
      */
@@ -58,8 +53,9 @@ public class XMLHttpRequestEventTarget extends EventTarget {
         throw ScriptRuntime.typeError("Illegal constructor.");
     }
 
+    @Deprecated
     public Function getFunctionForEvent(final String event) {
-        return eventMapping_.get(event);
+        return getEventHandler(event);
     }
 
     /**
@@ -68,7 +64,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOnload() {
-        return getFunctionForEvent(Event.TYPE_LOAD);
+        return getEventHandler(Event.TYPE_LOAD);
     }
 
     /**
@@ -77,7 +73,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnload(final Function loadHandler) {
-        eventMapping_.put(Event.TYPE_LOAD, loadHandler);
+        setEventHandler(Event.TYPE_LOAD, loadHandler);
     }
 
     /**
@@ -86,7 +82,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOnerror() {
-        return getFunctionForEvent(Event.TYPE_ERROR);
+        return getEventHandler(Event.TYPE_ERROR);
     }
 
     /**
@@ -95,7 +91,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnerror(final Function errorHandler) {
-        eventMapping_.put(Event.TYPE_ERROR, errorHandler);
+        setEventHandler(Event.TYPE_ERROR, errorHandler);
     }
 
     /**
@@ -104,7 +100,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOnloadstart() {
-        return getFunctionForEvent(Event.TYPE_LOAD_START);
+        return getEventHandler(Event.TYPE_LOAD_START);
     }
 
     /**
@@ -113,7 +109,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnloadstart(final Function loadstartHandler) {
-        eventMapping_.put(Event.TYPE_LOAD_START, loadstartHandler);
+        setEventHandler(Event.TYPE_LOAD_START, loadstartHandler);
     }
 
     /**
@@ -122,7 +118,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOnloadend() {
-        return getFunctionForEvent(Event.TYPE_LOAD_END);
+        return getEventHandler(Event.TYPE_LOAD_END);
     }
 
     /**
@@ -131,7 +127,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnloadend(final Function loadendHandler) {
-        eventMapping_.put(Event.TYPE_LOAD_END, loadendHandler);
+        setEventHandler(Event.TYPE_LOAD_END, loadendHandler);
     }
 
     /**
@@ -140,7 +136,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOnprogress() {
-        return getFunctionForEvent(Event.TYPE_PROGRESS);
+        return getEventHandler(Event.TYPE_PROGRESS);
     }
 
     /**
@@ -149,7 +145,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnprogress(final Function progressHandler) {
-        eventMapping_.put(Event.TYPE_PROGRESS, progressHandler);
+        setEventHandler(Event.TYPE_PROGRESS, progressHandler);
     }
 
     /**
@@ -158,7 +154,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOntimeout() {
-        return getFunctionForEvent(Event.TYPE_TIMEOUT);
+        return getEventHandler(Event.TYPE_TIMEOUT);
     }
 
     /**
@@ -167,7 +163,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOntimeout(final Function timeoutHandler) {
-        eventMapping_.put(Event.TYPE_TIMEOUT, timeoutHandler);
+        setEventHandler(Event.TYPE_TIMEOUT, timeoutHandler);
     }
 
     /**
@@ -175,7 +171,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      * @return the event handler that fires on ready state change
      */
     public Function getOnreadystatechange() {
-        return getFunctionForEvent(Event.TYPE_READY_STATE_CHANGE);
+        return getEventHandler(Event.TYPE_READY_STATE_CHANGE);
     }
 
     /**
@@ -183,7 +179,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      * @param readyStateChangeHandler the event handler that fires on ready state change
      */
     public void setOnreadystatechange(final Function readyStateChangeHandler) {
-        eventMapping_.put(Event.TYPE_READY_STATE_CHANGE, readyStateChangeHandler);
+        setEventHandler(Event.TYPE_READY_STATE_CHANGE, readyStateChangeHandler);
     }
 
     /**
@@ -192,7 +188,7 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxGetter
     public Function getOnabort() {
-        return getFunctionForEvent(Event.TYPE_ABORT);
+        return getEventHandler(Event.TYPE_ABORT);
     }
 
     /**
@@ -201,6 +197,6 @@ public class XMLHttpRequestEventTarget extends EventTarget {
      */
     @JsxSetter
     public void setOnabort(final Function abortHandler) {
-        eventMapping_.put(Event.TYPE_ABORT, abortHandler);
+        setEventHandler(Event.TYPE_ABORT, abortHandler);
     }
 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest4Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest4Test.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.BrowserRunner;
+import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
 import com.gargoylesoftware.htmlunit.SimpleWebTestCase;
 import com.gargoylesoftware.htmlunit.WebWindow;
 
@@ -30,6 +31,7 @@ import com.gargoylesoftware.htmlunit.WebWindow;
  * @author Stuart Begg
  * @author Sudhan Moghe
  * @author Thorsten Wendelmuth
+ * @author Atsushi Nakagawa
  */
 @RunWith(BrowserRunner.class)
 public class XMLHttpRequest4Test extends SimpleWebTestCase {
@@ -97,6 +99,103 @@ public class XMLHttpRequest4Test extends SimpleWebTestCase {
         final WebWindow window = loadPage(content).getEnclosingWindow();
         assertEquals(0, window.getWebClient().waitForBackgroundJavaScriptStartingBefore(1000));
         assertEquals("about:blank", window.getEnclosedPage().getUrl());
+    }
+
+    /**
+     * Testing event invocation order
+     */
+    @Test
+    @Alerts(DEFAULT = {
+            "onreadystatechange_1: readyState=1",
+            "onreadystatechange_2: readyState=1",
+            "onreadystatechange_p: readyState=1",
+            "onreadystatechange_3: readyState=1",
+            "onreadystatechange_4: readyState=1",
+            "onreadystatechange_1: readyState=2",
+            "onreadystatechange_2: readyState=2",
+            "onreadystatechange_p: readyState=2",
+            "onreadystatechange_3: readyState=2",
+            "onreadystatechange_4: readyState=2",
+            "onreadystatechange_1: readyState=3",
+            "onreadystatechange_2: readyState=3",
+            "onreadystatechange_p: readyState=3",
+            "onreadystatechange_3: readyState=3",
+            "onreadystatechange_4: readyState=3",
+            "onreadystatechange_1: readyState=4",
+            "onreadystatechange_2: readyState=4",
+            "onreadystatechange_p: readyState=4",
+            "onreadystatechange_3: readyState=4",
+            "onreadystatechange_4: readyState=4",
+        }, IE = {
+            "onreadystatechange_1: readyState=1",
+            "onreadystatechange_2: readyState=1",
+            "onreadystatechange_p: readyState=1",
+            "onreadystatechange_3: readyState=1",
+            "onreadystatechange_4: readyState=1",
+            "onreadystatechange_1: readyState=1",
+            "onreadystatechange_2: readyState=1",
+            "onreadystatechange_p: readyState=1",
+            "onreadystatechange_3: readyState=1",
+            "onreadystatechange_4: readyState=1",
+            "onreadystatechange_1: readyState=2",
+            "onreadystatechange_2: readyState=2",
+            "onreadystatechange_p: readyState=2",
+            "onreadystatechange_3: readyState=2",
+            "onreadystatechange_4: readyState=2",
+            "onreadystatechange_1: readyState=3",
+            "onreadystatechange_2: readyState=3",
+            "onreadystatechange_p: readyState=3",
+            "onreadystatechange_3: readyState=3",
+            "onreadystatechange_4: readyState=3",
+            "onreadystatechange_1: readyState=4",
+            "onreadystatechange_2: readyState=4",
+            "onreadystatechange_p: readyState=4",
+            "onreadystatechange_3: readyState=4",
+            "onreadystatechange_4: readyState=4",
+    })
+    public void eventInvocationOrder() throws Exception {
+        final String html = ""
+            + "<html>\n"
+            + "<head>\n"
+            + "<script>\n"
+            + "function test() {\n"
+            + "    var xhr = new XMLHttpRequest();\n"
+            + "\n"
+            + "    var onreadystatechange_1 = function (e) {\n"
+            + "        alert('onreadystatechange_1: readyState=' + xhr.readyState);\n"
+            + "    }\n"
+            + "    var onreadystatechange_2 = function (e) {\n"
+            + "        alert('onreadystatechange_2: readyState=' + xhr.readyState);\n"
+            + "        e.stopPropagation();\n"
+            + "    }\n"
+            + "    var onreadystatechange_3 = function (e) {\n"
+            + "        alert('onreadystatechange_3: readyState=' + xhr.readyState);\n"
+            + "        e.stopPropagation();\n"
+            + "    }\n"
+            + "    var onreadystatechange_4 = function (e) {\n"
+            + "        alert('onreadystatechange_4: readyState=' + xhr.readyState);\n"
+            + "    }\n"
+            + "\n"
+            + "    var onreadystatechange_p = function (e) {\n"
+            + "        alert('onreadystatechange_p: readyState=' + xhr.readyState);\n"
+            + "    }\n"
+            + "\n"
+            + "    xhr.addEventListener('readystatechange', onreadystatechange_1, false);\n"
+            + "    xhr.addEventListener('readystatechange', onreadystatechange_2, true);\n"
+            + "    xhr.onreadystatechange = onreadystatechange_p;\n"
+            + "    xhr.addEventListener('readystatechange', onreadystatechange_3, false);\n"
+            + "    xhr.addEventListener('readystatechange', onreadystatechange_4, true);\n"
+            + "    xhr.open('GET', 'foo.xml');\n"
+            + "    xhr.send();\n"
+            + "}\n"
+            + "</script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "</body>\n"
+            + "</html>\n";
+
+        getMockWebConnection().setDefaultResponse("");
+        loadPageWithAlerts(html, URL_FIRST, 1000);
     }
 
 }


### PR DESCRIPTION
## Problem in brief

This PR changes the invocation order of events added to `XMLHttpRequest`, through both `addEventListener()` and on-handlers, to be more consistent with major browser such as Chrome / FF / IE, as well as other events already implemented in HtmlUnit that use [EventTarget's framework](https://github.com/HtmlUnit/htmlunit/blob/master/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/event/EventTarget.java#L114).

## Technical details

This is done by using the [AT_TARGET invocation feature](https://github.com/HtmlUnit/htmlunit/blob/master/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/event/EventTarget.java#L93) previously added to EventTarget, which is a more robust implementation than the custom implementation in `XMLHttpRequest`.

Consequently, the use of `EventTarget.executeEventLocally()` to handle `XMLHttpRequest`'s events also has this added benefits:
* `window.currentEvent` is now set correctly throughout the event invocation
* `event.eventPhase` is set to a value consistent with major browsers

## Notes

* I was initially worried because at a glance [the `scope` parameter of `callFunction()`](https://github.com/HtmlUnit/htmlunit/blob/2.45.0/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequest.java#L242) changes from `function.getParentScope()` to [a `Window` instance when invoked through](https://github.com/HtmlUnit/htmlunit/blob/2.45.0/src/main/java/com/gargoylesoftware/htmlunit/javascript/JavaScriptEngine.java#L848) `EventTarget.executeEventLocally()`, but reading the code deeper it's not used anywhere before it's [reverted to back to the same `fnOrScript.getParentScope()` instance](https://github.com/HtmlUnit/htmlunit-rhino-fork/blob/5ff6bb8a71c5762af692102278ceeffb94d688b2/src/org/mozilla/javascript/Interpreter.java#L127) in `initializeArgs()` so this PR is essentially a pure refactor here.

* This PR also *deprecates* the [public method `XMLHttpRequestEventTarget.getFunctionForEvent()`](https://github.com/HtmlUnit/htmlunit/blob/2.45.0/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequestEventTarget.java#L61) because I could not think of a benefit of keeping it `public`.  The same functionality is provided [through `EventTarget.getEventHandler()`](https://github.com/HtmlUnit/htmlunit/blob/1fa638aee21d58b4f3cffa3ffb5d14942ed1ebf6/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLHttpRequestEventTarget.java#L58) which this class inherits.