### PR TITLE
SubtleCrypto: Fix to return a rejected Promise rather than throw errors

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/crypto/SubtleCrypto.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/crypto/SubtleCrypto.java
@@ -22,6 +22,9 @@ import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBr
 import com.gargoylesoftware.htmlunit.javascript.SimpleScriptable;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxConstructor;
+import com.gargoylesoftware.htmlunit.javascript.configuration.JsxFunction;
+import com.gargoylesoftware.htmlunit.javascript.host.Promise;
+import com.gargoylesoftware.htmlunit.javascript.host.dom.DOMException;
 
 /**
  * A JavaScript object for {@code SubtleCrypto}.
@@ -37,6 +40,67 @@ public class SubtleCrypto extends SimpleScriptable {
      */
     @JsxConstructor({CHROME, EDGE, FF, FF78})
     public SubtleCrypto() {
+    }
+
+    private Promise notImplemented() {
+        return Promise.reject(null, this, new Object[] {
+                new DOMException("Operation is not supported", DOMException.NOT_SUPPORTED_ERR),
+        }, null);
+    }
+
+    @JsxFunction
+    public Promise encrypt() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise decrypt() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise sign() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise verify() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise digest() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise generateKey() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise deriveKey() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise importKey() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise exportKey() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise wrapKey() {
+        return notImplemented();
+    }
+
+    @JsxFunction
+    public Promise unwrapKey() {
+        return notImplemented();
     }
 
 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/crypto/SubtleCryptoTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/crypto/SubtleCryptoTest.java
@@ -32,9 +32,35 @@ import com.gargoylesoftware.htmlunit.WebDriverTestCase;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Atsushi Nakagawa
  */
 @RunWith(BrowserRunner.class)
 public class SubtleCryptoTest extends WebDriverTestCase {
+
+    /**
+     * Methods in SubtleCrypto should always wraps errors in a Promise and never throw directly
+     */
+    @Test
+    @Alerts(DEFAULT = {"[object DOMException]"}, IE = {})
+    public void unsupportedCall() throws Exception {
+        final String html
+            = ""
+            + "<html><head><script>\n"
+            + "  function test() {\n"
+            + "    if (window.crypto) {\n"
+            + "      window.crypto.subtle.generateKey(\n"
+            + "        { name: 'x' }\n"
+            + "      )\n"
+            + "      .catch(function(err) {\n"
+            + "        alert(err);\n"
+            + "      });\n"
+            + "    }\n"
+            + "  }\n"
+            + "</script></head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageWithAlerts2(html, URL_FIRST, DEFAULT_WAIT_TIME * 3);
+    }
 
     /**
      * @throws Exception if the test fails


### PR DESCRIPTION
## Problem in brief

This PR implements a placeholder version of each of the documented methods of SubtleCrypto so that they return a rejected Promise when called rather than throw an error.

This is because [all SubtleCrypto's function](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) should return a rejected `Promise` to express errors (in the fashion of an *async function*), rather than throw errors directly, and this rule should probably hold in the name of compatibility when functionality is not implemented also.

## Technical detail

* I decided to use `DOMException(message = "Operation is not supported", code = 8)` for the error to put into the Promise because that's the error used by Firefox 84 when the algorithm name specified to `generatedKey()` is not supported.

## Notes

* Eventually, the person implementing each method of `SubtleCrypto` might find it very tedious to do this through `@JsxFunction` as they'll need to repeat the Promise returning code for each method.  Perhaps if it were to come to it, a more useful annotation such as `@JsxAsyncFunction` can be devised which automatically calls the Java method asynchronously on the JS executor thread and wrap the result as a Promise.
