### PR TITLE
Corrections to width calculations.

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlImage.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlImage.java
@@ -20,6 +20,8 @@ import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.HTMLIMAGE_HTM
 import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.HTMLIMAGE_HTMLUNKNOWNELEMENT;
 import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.HTMLIMAGE_INVISIBLE_NO_SRC;
 import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_IMAGE_COMPLETE_RETURNS_TRUE_FOR_NO_REQUEST;
+import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_IMAGE_WIDTH_HEIGHT_RETURNS_16x16_0x0;
+import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_IMAGE_WIDTH_HEIGHT_RETURNS_28x30_28x30;
 
 import java.io.File;
 import java.io.IOException;
@@ -462,6 +464,22 @@ public class HtmlImage extends HtmlElement {
         }
         return height_;
     }
+    
+    public int getHeightOrDefault() {
+    	if (getPage().getWebClient().getOptions().isDownloadImages()) {
+			try {
+				return getHeight();
+			} catch (IOException e) {}
+    	}
+    	final BrowserVersion browserVersion = getPage().getWebClient().getBrowserVersion();
+    	if (browserVersion.hasFeature(JS_IMAGE_WIDTH_HEIGHT_RETURNS_28x30_28x30)) {
+            return 30;
+        }
+        if (browserVersion.hasFeature(JS_IMAGE_WIDTH_HEIGHT_RETURNS_16x16_0x0)) {
+            return 16;
+        }
+        return 24;
+    }
 
     /**
      * <p>Returns the image's actual width (<b>not</b> the image's {@link #getWidthAttribute() width attribute}).</p>
@@ -476,6 +494,22 @@ public class HtmlImage extends HtmlElement {
             determineWidthAndHeight();
         }
         return width_;
+    }
+    
+    public int getWidthOrDefault() {
+    	if (getPage().getWebClient().getOptions().isDownloadImages()) {
+			try {
+				return getWidth();
+			} catch (IOException e) {}
+    	}
+    	final BrowserVersion browserVersion = getPage().getWebClient().getBrowserVersion();
+    	if (browserVersion.hasFeature(JS_IMAGE_WIDTH_HEIGHT_RETURNS_28x30_28x30)) {
+            return 28;
+        }
+        if (browserVersion.hasFeature(JS_IMAGE_WIDTH_HEIGHT_RETURNS_16x16_0x0)) {
+            return 16;
+        }
+        return 24;
     }
 
     /**


### PR DESCRIPTION
Corrections to width calculations: handled some missing cases + corrected some existing widths.

1. getCalculatedWidth: 'display:block' elements will lookup at parent's calculated width, instead of solely looking at 'width' attribute.
2. getCalculatedWidth: HtmlImage's width will be calculated according to image dimensions (it was defaulting to the 'else' part, always returning 0 via getContentWidth()).
3. getContentWidth: child with 'display:none' will have width 0.
4. getContentWidth: 'script' tags will have width 0 (previously it was calculated according to their text content).
5. getContentWidth: before proceeding to checking content's length, we'll check the 'style=width:X' attribute - if it exists then this is our width.
6. getContentWidth: HtmlImage's width will be calculated according to image dimensions (previously it was calculated by length of text content).
7. getContentWidth: HTMLElement's content width must be calculated with getContentWidth(). getCalculatedWidth() will not work correctly for inline-block calculations.
8. getContentWidth: Text elements should be trimmed when calculating content's width - this is how browsers handle text. Llimitation: there is currently no way to differentiate between &nbsp; tags and actual space.
9. getContentWidth: spaces/indentation between tags are sometimes rendered as Text nodes, consisting of whitespace. Solution in bullet 8 will prevent these from adding length to width calculations (important!)
10. getLeft: should rely on parent's calculated length, not solely on parent's 'width' attribute (requires further testing).

