### PR TITLE
Fixes for CSSMediaRule (#360)

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,6 +8,15 @@
 
     <body>
         <release version="2.51.0" date="June xx, 2021" description="Bugfixes, Firefox 89, Chrome/Edge 91, JS Template support">
+            <action type="add" dev="rbri" due-to="Frank Danek" issue="360">
+                CSSConditionRule.conditionText added (for CSSMediaRule).
+            </action>
+            <action type="add" dev="rbri" due-to="Frank Danek" issue="360">
+                CSSGroupingRule.cssRules, .insertRule() and .deleteRule() added (for CSSMediaRule).
+            </action>
+            <action type="fix" dev="rbri" due-to="Frank Danek" issue="360">
+                MediaList default toString() now prints the media text.
+            </action>
             <action type="add" dev="rbri" due-to="Frank Danek">
                 HtmlImage.getSrc() added.
             </action>

--- a/src/main/java/com/gargoylesoftware/htmlunit/BrowserVersionFeatures.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/BrowserVersionFeatures.java
@@ -21,6 +21,7 @@ import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBr
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.IE;
 
 import com.gargoylesoftware.htmlunit.javascript.configuration.BrowserFeature;
+import com.gargoylesoftware.htmlunit.javascript.host.css.CSSGroupingRule;
 import com.gargoylesoftware.htmlunit.javascript.host.event.PopStateEvent;
 import com.gargoylesoftware.htmlunit.javascript.host.intl.DateTimeFormat;
 
@@ -975,6 +976,10 @@ public enum BrowserVersionFeatures {
     @BrowserFeature(IE)
     JS_FRAME_CONTENT_DOCUMENT_ACCESS_DENIED_THROWS,
 
+    /** The index parameter of {@link CSSGroupingRule#insertRule(String, Object)} is optional. */
+    @BrowserFeature({FF, FF78})
+    JS_GROUPINGRULE_INSERTRULE_INDEX_OPTIONAL,
+
     /** HTMLElement instead of HTMLUnknownElement for elements with hyphen ('-'). */
     @BrowserFeature({CHROME, EDGE, FF, FF78})
     JS_HTML_HYPHEN_ELEMENT_CLASS_NAME,
@@ -1141,7 +1146,7 @@ public enum BrowserVersionFeatures {
     @BrowserFeature(IE)
     JS_MEDIA_LIST_ALL,
 
-    /** Indicates that an empty media list is represented by the string 'all'. */
+    /** Indicates that an empty media list is represented by the string ''. */
     @BrowserFeature({CHROME, EDGE, FF, FF78})
     JS_MEDIA_LIST_EMPTY_STRING,
 
@@ -1591,7 +1596,6 @@ public enum BrowserVersionFeatures {
 
     /**
      * Method addRule returns the rule position instead of -1.
-     * (href empty) is null.
      */
     @BrowserFeature(IE)
     STYLESHEET_ADD_RULE_RETURNS_POS,

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSConditionRule.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSConditionRule.java
@@ -23,12 +23,15 @@ import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBr
 import com.gargoylesoftware.css.dom.CSSMediaRuleImpl;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxConstructor;
+import com.gargoylesoftware.htmlunit.javascript.configuration.JsxGetter;
 
 /**
  * A JavaScript object for {@code CSSConditionRule}.
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSSConditionRule">MDN doc</a>
  */
 @JsxClass({CHROME, EDGE, FF, FF78})
 @JsxClass(isJSObject = false, value = IE)
@@ -50,4 +53,20 @@ public class CSSConditionRule extends CSSGroupingRule {
         super(stylesheet, rule);
     }
 
+    /**
+     * Returns the text of the condition of the rule.
+     * @return the text of the condition of the rule
+     */
+    @JsxGetter({CHROME, EDGE, FF, FF78})
+    public String getConditionText() {
+        return getConditionRule().getMediaList().getMediaText();
+    }
+
+    /**
+     * Returns the wrapped rule, as a media rule.
+     * @return the wrapped rule, as a media rule
+     */
+    private CSSMediaRuleImpl getConditionRule() {
+        return (CSSMediaRuleImpl) getRule();
+    }
 }

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSGroupingRule.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSGroupingRule.java
@@ -14,25 +14,46 @@
  */
 package com.gargoylesoftware.htmlunit.javascript.host.css;
 
+import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_GROUPINGRULE_INSERTRULE_INDEX_OPTIONAL;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.CHROME;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.EDGE;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF78;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.IE;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.w3c.dom.DOMException;
+
+import com.gargoylesoftware.css.dom.AbstractCSSRuleImpl;
+import com.gargoylesoftware.css.dom.CSSCharsetRuleImpl;
 import com.gargoylesoftware.css.dom.CSSMediaRuleImpl;
+import com.gargoylesoftware.css.dom.CSSRuleListImpl;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxConstructor;
+import com.gargoylesoftware.htmlunit.javascript.configuration.JsxFunction;
+import com.gargoylesoftware.htmlunit.javascript.configuration.JsxGetter;
+
+import net.sourceforge.htmlunit.corejs.javascript.Context;
+import net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime;
+import net.sourceforge.htmlunit.corejs.javascript.Undefined;
 
 /**
  * A JavaScript object for {@code CSSGroupingRule}.
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSSGroupingRule">MDN doc</a>
  */
 @JsxClass({CHROME, EDGE, FF, FF78})
 @JsxClass(isJSObject = false, value = IE)
 public class CSSGroupingRule extends CSSRule {
+
+    /** The collection of rules defined in this rule. */
+    private com.gargoylesoftware.htmlunit.javascript.host.css.CSSRuleList cssRules_;
+    private List<Integer> cssRulesIndexFix_;
 
     /**
      * Creates a new instance.
@@ -50,4 +71,128 @@ public class CSSGroupingRule extends CSSRule {
         super(stylesheet, rule);
     }
 
+    /**
+     * Returns the collection of rules defined in this rule.
+     * @return the collection of rules defined in this rule
+     */
+    @JsxGetter
+    public CSSRuleList getCssRules() {
+        initCssRules();
+        return cssRules_;
+    }
+
+    /**
+     * Inserts a new rule.
+     * @param rule the CSS rule
+     * @param position the position at which to insert the rule
+     * @return the position of the inserted rule
+     */
+    @JsxFunction
+    public int insertRule(final String rule, final Object position) {
+        final int positionInt;
+        if (position == null) {
+            positionInt = 0;
+        } else if (Undefined.isUndefined(position)) {
+            if (getBrowserVersion().hasFeature(JS_GROUPINGRULE_INSERTRULE_INDEX_OPTIONAL)) {
+                positionInt = 0;
+            } else {
+                throw ScriptRuntime.typeError("Failed to execute 'insertRule' on 'CSSGroupingRule': 2 arguments required, but only 1 present.");
+            }
+        } else {
+            positionInt = ScriptRuntime.toInt32(position);
+        }
+
+        try {
+            initCssRules();
+            getGroupingRule().insertRule(rule, fixIndex(positionInt));
+            refreshCssRules();
+            return positionInt;
+        }
+        catch (final DOMException e) {
+            // in case of error try with an empty rule
+            final int pos = rule.indexOf('{');
+            if (pos > -1) {
+                final String newRule = rule.substring(0, pos) + "{}";
+                try {
+                    getGroupingRule().insertRule(newRule, fixIndex(positionInt));
+                    refreshCssRules();
+                    return positionInt;
+                }
+                catch (final DOMException ex) {
+                    throw Context.throwAsScriptRuntimeEx(ex);
+                }
+            }
+            throw Context.throwAsScriptRuntimeEx(e);
+        }
+    }
+
+    /**
+     * Deletes an existing rule.
+     * @param position the position of the rule to be deleted
+     */
+    @JsxFunction
+    public void deleteRule(final int position) {
+        try {
+            initCssRules();
+            getGroupingRule().deleteRule(fixIndex(position));
+            refreshCssRules();
+        }
+        catch (final DOMException e) {
+            throw Context.throwAsScriptRuntimeEx(e);
+        }
+    }
+
+    private void initCssRules() {
+        if (cssRules_ == null) {
+            cssRules_ = new CSSRuleList(this);
+            cssRulesIndexFix_ = new ArrayList<>();
+            refreshCssRules();
+        }
+    }
+
+    private int fixIndex(int index) {
+        for (final int fix : cssRulesIndexFix_) {
+            if (fix > index) {
+                return index;
+            }
+            index++;
+        }
+        return index;
+    }
+
+    private void refreshCssRules() {
+        if (cssRules_ == null) {
+            return;
+        }
+
+        cssRules_.clearRules();
+        cssRulesIndexFix_.clear();
+
+        final CSSRuleListImpl ruleList = getGroupingRule().getCssRules();
+        final List<AbstractCSSRuleImpl> rules = ruleList.getRules();
+        int pos = 0;
+        for (final AbstractCSSRuleImpl rule : rules) {
+            if (rule instanceof CSSCharsetRuleImpl) {
+                cssRulesIndexFix_.add(pos);
+                continue;
+            }
+
+            final CSSRule cssRule = CSSRule.create(getParentStyleSheet(), rule);
+            if (null == cssRule) {
+                cssRulesIndexFix_.add(pos);
+            }
+            else {
+                cssRules_.addRule(cssRule);
+            }
+            pos++;
+        }
+    }
+
+    /**
+     * Returns the wrapped rule, as a media rule.
+     * @return the wrapped rule, as a media rule
+     */
+    private CSSMediaRuleImpl getGroupingRule() {
+        return (CSSMediaRuleImpl) getRule();
+    }
 }

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSMediaRule.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSMediaRule.java
@@ -18,19 +18,25 @@ import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBr
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.EDGE;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF;
 import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.FF78;
+import static com.gargoylesoftware.htmlunit.javascript.configuration.SupportedBrowser.IE;
 
 import com.gargoylesoftware.css.dom.CSSMediaRuleImpl;
 import com.gargoylesoftware.css.dom.MediaListImpl;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxConstructor;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxGetter;
+import com.gargoylesoftware.htmlunit.javascript.configuration.JsxSetter;
 import com.gargoylesoftware.htmlunit.javascript.host.dom.MediaList;
+
+import net.sourceforge.htmlunit.corejs.javascript.Context;
 
 /**
  * A JavaScript object for a {@link CSSMediaRuleImpl}.
  *
  * @author Ronald Brill
  * @author Ahmed Ashour
+ * @author Frank Danek
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSSMediaRule">MDN doc</a>
  */
 @JsxClass
 public class CSSMediaRule extends CSSConditionRule {
@@ -51,6 +57,15 @@ public class CSSMediaRule extends CSSConditionRule {
      */
     protected CSSMediaRule(final CSSStyleSheet stylesheet, final CSSMediaRuleImpl rule) {
         super(stylesheet, rule);
+    }
+
+    /**
+     * Sets the parsable textual representation of the rule.
+     * @param cssText the parsable textual representation of the rule
+     */
+    @JsxSetter(IE)
+    public void setCssText(final String cssText) {
+        Context.reportError("Not implemented.");
     }
 
     /**

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSRule.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSRule.java
@@ -243,15 +243,6 @@ public class CSSRule extends SimpleScriptable {
     }
 
     /**
-     * Sets the parsable textual representation of the rule.
-     * @param cssText the parsable textual representation of the rule
-     */
-    @JsxSetter(IE)
-    public void setCssText(final String cssText) {
-        rule_.setCssText(cssText);
-    }
-
-    /**
      * Returns the style sheet that contains this rule.
      * @return the style sheet that contains this rule.
      */

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSRule.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSRule.java
@@ -44,6 +44,7 @@ import com.gargoylesoftware.htmlunit.javascript.configuration.JsxSetter;
  * @author Ahmed Ashour
  * @author Frank Danek
  * @author Ronald Brill
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSSRule">MDN doc</a>
  */
 @JsxClass
 public class CSSRule extends SimpleScriptable {
@@ -245,7 +246,7 @@ public class CSSRule extends SimpleScriptable {
      * Sets the parsable textual representation of the rule.
      * @param cssText the parsable textual representation of the rule
      */
-    @JsxSetter({FF, FF78, IE})
+    @JsxSetter(IE)
     public void setCssText(final String cssText) {
         rule_.setCssText(cssText);
     }

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSRuleList.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSRuleList.java
@@ -36,6 +36,8 @@ import net.sourceforge.htmlunit.corejs.javascript.Scriptable;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Frank Danek
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSSRuleList">MDN doc</a>
  */
 @JsxClass
 public class CSSRuleList extends SimpleScriptable {
@@ -55,6 +57,15 @@ public class CSSRuleList extends SimpleScriptable {
      */
     public CSSRuleList(final CSSStyleSheet stylesheet) {
         setParentScope(stylesheet.getParentScope());
+        setPrototype(getPrototype(getClass()));
+    }
+
+    /**
+     * Creates a new instance.
+     * @param groupingRule the grouping rule
+     */
+    public CSSRuleList(final CSSGroupingRule groupingRule) {
+        setParentScope(groupingRule.getParentScope());
         setPrototype(getPrototype(getClass()));
     }
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/dom/MediaList.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/dom/MediaList.java
@@ -97,14 +97,17 @@ public class MediaList extends SimpleScriptable {
 
     @Override
     public Object getDefaultValue(final Class<?> hint) {
-        if (getPrototype() != null) {
-            final BrowserVersion browserVersion = getBrowserVersion();
-            if (browserVersion.hasFeature(JS_MEDIA_LIST_EMPTY_STRING)) {
-                return "";
+        if (getPrototype() != null && wrappedList_ != null) {
+            if (wrappedList_.getLength() == 0) {
+                final BrowserVersion browserVersion = getBrowserVersion();
+                if (browserVersion.hasFeature(JS_MEDIA_LIST_EMPTY_STRING)) {
+                    return "";
+                }
+                if (browserVersion.hasFeature(JS_MEDIA_LIST_ALL)) {
+                    return "all";
+                }
             }
-            if (browserVersion.hasFeature(JS_MEDIA_LIST_ALL)) {
-                return "all";
-            }
+            return wrappedList_.getMediaText();
         }
         return super.getDefaultValue(hint);
     }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSImportRuleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSImportRuleTest.java
@@ -111,7 +111,7 @@ public class CSSImportRuleTest extends WebDriverTestCase {
             EDGE = "@import url(imp.css);",
             FF = "@import url(imp.css);",
             FF78 = "@import url(imp.css);",
-            IE = "@import url(imp2.css);")
+            IE = "@import url(imp.css);")
     public void cssTextSet() throws Exception {
         final String html
             = "<html><body>\n"

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSImportRuleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSImportRuleTest.java
@@ -109,8 +109,8 @@ public class CSSImportRuleTest extends WebDriverTestCase {
             IE = "@import url( imp.css );")
     @HtmlUnitNYI(CHROME = "@import url(imp.css);",
             EDGE = "@import url(imp.css);",
-            FF = "@import url(imp2.css);",
-            FF78 = "@import url(imp2.css);",
+            FF = "@import url(imp.css);",
+            FF78 = "@import url(imp.css);",
             IE = "@import url(imp2.css);")
     public void cssTextSet() throws Exception {
         final String html
@@ -413,11 +413,11 @@ public class CSSImportRuleTest extends WebDriverTestCase {
     @Test
     @Alerts(DEFAULT = {"[object MediaList]", "screen", "1", "screen", "screen", "@import url(\"imp.css\") screen;"},
             IE = {"[object MediaList]", "screen", "1", "screen", "screen", "@import url( imp.css ) screen;"})
-    @HtmlUnitNYI(CHROME = {"[object MediaList]", "", "1", "screen", "screen", "@import url(imp.css) screen;"},
-            EDGE = {"[object MediaList]", "", "1", "screen", "screen", "@import url(imp.css) screen;"},
-            FF = {"[object MediaList]", "", "1", "screen", "screen", "@import url(imp.css) screen;"},
-            FF78 = {"[object MediaList]", "", "1", "screen", "screen", "@import url(imp.css) screen;"},
-            IE = {"[object MediaList]", "all", "1", "screen", "screen", "@import url(imp.css) screen;"})
+    @HtmlUnitNYI(CHROME = {"[object MediaList]", "screen", "1", "screen", "screen", "@import url(imp.css) screen;"},
+            EDGE = {"[object MediaList]", "screen", "1", "screen", "screen", "@import url(imp.css) screen;"},
+            FF = {"[object MediaList]", "screen", "1", "screen", "screen", "@import url(imp.css) screen;"},
+            FF78 = {"[object MediaList]", "screen", "1", "screen", "screen", "@import url(imp.css) screen;"},
+            IE = {"[object MediaList]", "screen", "1", "screen", "screen", "@import url(imp.css) screen;"})
     public void media() throws Exception {
         final String html
             = "<html><body>\n"

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSMediaRuleTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/css/CSSMediaRuleTest.java
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 import com.gargoylesoftware.htmlunit.BrowserRunner;
 import com.gargoylesoftware.htmlunit.BrowserRunner.Alerts;
 import com.gargoylesoftware.htmlunit.BrowserRunner.HtmlUnitNYI;
-import com.gargoylesoftware.htmlunit.BrowserRunner.NotYetImplemented;
 import com.gargoylesoftware.htmlunit.WebDriverTestCase;
 
 /**
@@ -69,6 +68,7 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
             FF = "@media screen {p { background-color: rgb(255, 255, 255) } }",
             FF78 = "@media screen {p { background-color: rgb(255, 255, 255) } }",
             IE = "@media screen {p { background-color: rgb(255, 255, 255) } }")
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void cssText() throws Exception {
         final String html
             = "<html><body>\n"
@@ -99,9 +99,9 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
             IE = "exception")
     @HtmlUnitNYI(CHROME = "@media screen {p { background-color: rgb(255, 255, 255) } }",
             EDGE = "@media screen {p { background-color: rgb(255, 255, 255) } }",
-            FF = "@media screen {span { color: rgb(0, 0, 0) } }",
-            FF78 = "@media screen {span { color: rgb(0, 0, 0) } }",
-            IE = "@media screen {span { color: rgb(0, 0, 0) } }")
+            FF = "@media screen {p { background-color: rgb(255, 255, 255) } }",
+            FF78 = "@media screen {p { background-color: rgb(255, 255, 255) } }")
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void cssTextSet() throws Exception {
         final String html
             = "<html><body>\n"
@@ -245,11 +245,6 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
     @Test
     @Alerts(DEFAULT = {"[object MediaList]", "screen", "1", "screen", "screen", "screen"},
             IE = {"[object MediaList]", "screen", "1", "screen", "screen", "undefined"})
-    @HtmlUnitNYI(CHROME = {"[object MediaList]", "", "1", "screen", "screen", "undefined"},
-            EDGE = {"[object MediaList]", "", "1", "screen", "screen", "undefined"},
-            FF = {"[object MediaList]", "", "1", "screen", "screen", "undefined"},
-            FF78 = {"[object MediaList]", "", "1", "screen", "screen", "undefined"},
-            IE = {"[object MediaList]", "all", "1", "screen", "screen", "undefined"})
     public void media() throws Exception {
         final String html
             = "<html><body>\n"
@@ -285,16 +280,12 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
     @Alerts(DEFAULT = {"2", "only screen and (color)", "print", "only screen and (color), print",
                        "only screen and (color), print"},
             IE = {"2", "only screen and (color)", "print", "only screen and (color), print", "undefined"})
-    @HtmlUnitNYI(CHROME = {"2", "only screen and (color)", "print", "only screen and (color), print", "undefined"},
-            EDGE = {"2", "only screen and (color)", "print", "only screen and (color), print", "undefined"},
-            FF = {"2", "only screen and (color)", "print", "only screen and (color), print", "undefined"},
-            FF78 = {"2", "only screen and (color)", "print", "only screen and (color), print", "undefined"})
     public void mediaQuery() throws Exception {
         final String html
             = "<html><body>\n"
 
             + "<style>\n"
-            + "  @media only screen and (color), print { p { background-color:#FFFFFF; }};\n"
+            + "  @media only screen and (color),print { p { background-color:#FFFFFF; }};\n"
             + "</style>\n"
 
             + "<script>\n"
@@ -321,7 +312,17 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
     @Test
     @Alerts({"[object CSSRuleList]", "[object CSSRuleList]", "1", "[object CSSStyleRule]",
              "p { background-color: rgb(255, 255, 255); }", "[object CSSMediaRule]"})
-    @NotYetImplemented
+    @HtmlUnitNYI(CHROME = {"[object CSSRuleList]", "[object CSSRuleList]", "1", "[object CSSStyleRule]",
+                           "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            EDGE = {"[object CSSRuleList]", "[object CSSRuleList]", "1", "[object CSSStyleRule]",
+                    "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            IE = {"[object CSSRuleList]", "[object CSSRuleList]", "1", "[object CSSStyleRule]",
+                  "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            FF = {"[object CSSRuleList]", "[object CSSRuleList]", "1", "[object CSSStyleRule]",
+                  "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            FF78 = {"[object CSSRuleList]", "[object CSSRuleList]", "1", "[object CSSStyleRule]",
+                    "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"})
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void cssRules() throws Exception {
         final String html
             = "<html><body>\n"
@@ -359,7 +360,12 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
                   "p { background-color: rgb(255, 255, 255); }", "[object CSSMediaRule]"},
             FF78 = {"1", "0", "2", "span { color: rgb(0, 0, 0); }", "[object CSSMediaRule]",
                     "p { background-color: rgb(255, 255, 255); }", "[object CSSMediaRule]"})
-    @NotYetImplemented
+    @HtmlUnitNYI(FF = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                       "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            FF78 = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                    "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"})
+    // FIXME set rule.parentRule in CSSMediaRuleImpl.insertRule(String, int) -> CSSParser
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void insertRule() throws Exception {
         final String html
             = "<html><body>\n"
@@ -487,7 +493,18 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
     @Test
     @Alerts({"1", "1", "2", "p { background-color: rgb(255, 255, 255); }", "[object CSSMediaRule]",
              "span { color: rgb(0, 0, 0); }", "[object CSSMediaRule]"})
-    @NotYetImplemented
+    @HtmlUnitNYI(CHROME = {"1", "1", "2", "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]",
+                           "span { color: rgb(0, 0, 0) }", "null"},
+            EDGE = {"1", "1", "2", "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]",
+                    "span { color: rgb(0, 0, 0) }", "null"},
+            IE = {"1", "1", "2", "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]",
+                  "span { color: rgb(0, 0, 0) }", "null"},
+            FF = {"1", "1", "2", "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]",
+                  "span { color: rgb(0, 0, 0) }", "null"},
+            FF78 = {"1", "1", "2", "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]",
+                    "span { color: rgb(0, 0, 0) }", "null"})
+    // FIXME set rule.parentRule in CSSMediaRuleImpl.insertRule(String, int) -> CSSParser
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void insertRuleWithIndex() throws Exception {
         final String html
             = "<html><body>\n"
@@ -555,7 +572,7 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
     @Test
     @Alerts(DEFAULT = {"1", "exception"},
             IE = {"1", "-1", "1", "p { background-color: rgb(255, 255, 255); }", "[object CSSMediaRule]"})
-    @NotYetImplemented
+    @HtmlUnitNYI(IE = {"1", "exception"})
     public void insertRuleEmptyWithIndex() throws Exception {
         final String html
             = "<html><body>\n"
@@ -623,7 +640,18 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
     @Test
     @Alerts({"1", "0", "2", "span { color: rgb(0, 0, 0); }", "[object CSSMediaRule]",
              "p { background-color: rgb(255, 255, 255); }", "[object CSSMediaRule]"})
-    @NotYetImplemented
+    @HtmlUnitNYI(CHROME = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                           "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            EDGE = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                    "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            IE = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                  "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            FF = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                  "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            FF78 = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                    "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"})
+    // FIXME set rule.parentRule in CSSMediaRuleImpl.insertRule(String, int) -> CSSParser
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void insertRuleWithIndexNull() throws Exception {
         final String html
             = "<html><body>\n"
@@ -646,7 +674,56 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
             + "      log(rules.item(i).parentRule);\n"
             + "    }\n"
             + "  } catch(e) {\n"
-            + "    log('exception');\n"
+            + "    log('exception'+e);\n"
+            + "  }\n"
+            + "</script>\n"
+
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"1", "0", "2", "span { color: rgb(0, 0, 0); }", "[object CSSMediaRule]",
+             "p { background-color: rgb(255, 255, 255); }", "[object CSSMediaRule]"})
+    @HtmlUnitNYI(CHROME = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                           "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            EDGE = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                    "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            IE = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                  "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            FF = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                  "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"},
+            FF78 = {"1", "0", "2", "span { color: rgb(0, 0, 0) }", "null",
+                    "p { background-color: rgb(255, 255, 255) }", "[object CSSMediaRule]"})
+    // FIXME set rule.parentRule in CSSMediaRuleImpl.insertRule(String, int) -> CSSParser
+    // FIXME output formatting in rule.cssText -> CSSParser
+    public void insertRuleWithIndexNaN() throws Exception {
+        final String html
+            = "<html><body>\n"
+
+            + "<style>\n"
+            + "  @media screen { p { background-color:#FFFFFF; }};\n"
+            + "</style>\n"
+
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  var styleSheet = document.styleSheets[0];\n"
+            + "  var rule = styleSheet.cssRules[0];\n"
+            + "  var rules = rule.cssRules;\n"
+            + "  log(rules.length);\n"
+            + "  try {\n"
+            + "    log(rule.insertRule('span { color:#000000; }', 'abc'));\n"
+            + "    log(rules.length);\n"
+            + "    for (var i = 0; i < rules.length; i++) {\n"
+            + "      log(rules.item(i).cssText);\n"
+            + "      log(rules.item(i).parentRule);\n"
+            + "    }\n"
+            + "  } catch(e) {\n"
+            + "    log('exception'+e);\n"
             + "  }\n"
             + "</script>\n"
 
@@ -660,7 +737,6 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
      */
     @Test
     @Alerts({"1", "exception"})
-    @NotYetImplemented
     public void insertRuleWithIndexNegative() throws Exception {
         final String html
             = "<html><body>\n"
@@ -692,7 +768,6 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
      */
     @Test
     @Alerts({"1", "exception"})
-    @NotYetImplemented
     public void insertRuleWithIndexGreaterThanLength() throws Exception {
         final String html
             = "<html><body>\n"
@@ -724,7 +799,12 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
      */
     @Test
     @Alerts({"2", "1", "p { background-color: rgb(255, 255, 255); }"})
-    @NotYetImplemented
+    @HtmlUnitNYI(CHROME = {"2", "1", "p { background-color: rgb(255, 255, 255) }"},
+            EDGE = {"2", "1", "p { background-color: rgb(255, 255, 255) }"},
+            IE = {"2", "1", "p { background-color: rgb(255, 255, 255) }"},
+            FF = {"2", "1", "p { background-color: rgb(255, 255, 255) }"},
+            FF78 = {"2", "1", "p { background-color: rgb(255, 255, 255) }"})
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void deleteRule() throws Exception {
         final String html
             = "<html><body>\n"
@@ -760,7 +840,12 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
      */
     @Test
     @Alerts({"2", "1", "span { color: rgb(0, 0, 0); }"})
-    @NotYetImplemented
+    @HtmlUnitNYI(CHROME = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            EDGE = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            IE = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            FF = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            FF78 = {"2", "1", "span { color: rgb(0, 0, 0) }"})
+    // FIXME output formatting in rule.cssText -> CSSParser
     public void deleteRuleNull() throws Exception {
         final String html
             = "<html><body>\n"
@@ -795,8 +880,48 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
      * @throws Exception if an error occurs
      */
     @Test
+    @Alerts({"2", "1", "span { color: rgb(0, 0, 0); }"})
+    @HtmlUnitNYI(CHROME = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            EDGE = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            IE = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            FF = {"2", "1", "span { color: rgb(0, 0, 0) }"},
+            FF78 = {"2", "1", "span { color: rgb(0, 0, 0) }"})
+    // FIXME output formatting in rule.cssText -> CSSParser
+    public void deleteRuleNaN() throws Exception {
+        final String html
+            = "<html><body>\n"
+
+            + "<style>\n"
+            + "  @media screen { p { background-color:#FFFFFF; } span { color: rgb(0, 0, 0); }};\n"
+            + "</style>\n"
+
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  var styleSheet = document.styleSheets[0];\n"
+            + "  var rule = styleSheet.cssRules[0];\n"
+            + "  var rules = rule.cssRules;\n"
+            + "  log(rules.length);\n"
+            + "  try {\n"
+            + "    rule.deleteRule('abc');\n"
+            + "    log(rules.length);\n"
+            + "    for (var i = 0; i < rules.length; i++) {\n"
+            + "      log(rules.item(i).cssText);\n"
+            + "    }\n"
+            + "  } catch(e) {\n"
+            + "    log('exception');\n"
+            + "  }\n"
+            + "</script>\n"
+
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
     @Alerts({"2", "exception"})
-    @NotYetImplemented
     public void deleteRuleNegative() throws Exception {
         final String html
             = "<html><body>\n"
@@ -828,7 +953,6 @@ public class CSSMediaRuleTest extends WebDriverTestCase {
      */
     @Test
     @Alerts({"2", "exception"})
-    @NotYetImplemented
     public void deleteRuleGreaterThanLength() throws Exception {
         final String html
             = "<html><body>\n"


### PR DESCRIPTION
For issue #360:
MediaList default toString() now prints the media text.
CSSGroupingRule.cssRules, .insertRule() and .deleteRule() added (for
CSSMediaRule).
CSSConditionRule.conditionText added (for CSSMediaRule).