### PR TITLE
Add missing browser headers when setting location

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/Location.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/Location.java
@@ -38,6 +38,7 @@ import org.apache.commons.logging.LogFactory;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebWindow;
+import com.gargoylesoftware.htmlunit.BrowserVersion;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.javascript.SimpleScriptable;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
@@ -237,10 +238,12 @@ public class Location extends SimpleScriptable {
                 }
             }
 
-            final WebRequest request = new WebRequest(url);
+            final WebWindow webWindow = window_.getWebWindow();
+
+            BrowserVersion bs = webWindow.getWebClient().getBrowserVersion();
+            final WebRequest request = new WebRequest(url, bs.getHtmlAcceptHeader(), bs.getAcceptEncodingHeader());
             request.setRefererlHeader(page.getUrl());
 
-            final WebWindow webWindow = window_.getWebWindow();
             webWindow.getWebClient().download(webWindow, "", request, true, false, false, "JS set location");
         }
         catch (final MalformedURLException e) {


### PR DESCRIPTION
The default headers of browser version is not set to the web request when changing the location. This is to fix that.