### PR TITLE
Fix code samples in "Getting Started with HtmlUnit"

### DIFF
--- a/src/site/xdoc/gettingStarted.xml
+++ b/src/site/xdoc/gettingStarted.xml
@@ -32,11 +32,11 @@
 @Test
 public void homePage() throws Exception {
     try (final WebClient webClient = new WebClient()) {
-        final HtmlPage page = webClient.getPage("http://htmlunit.sourceforge.net");
-        Assert.assertEquals("HtmlUnit - Welcome to HtmlUnit", page.getTitleText());
+        final HtmlPage page = webClient.getPage("https://htmlunit.sourceforge.io/");
+        Assert.assertEquals("HtmlUnit – Welcome to HtmlUnit", page.getTitleText());
 
         final String pageAsXml = page.asXml();
-        Assert.assertTrue(pageAsXml.contains("<body class=\"composite\">"));
+        Assert.assertTrue(pageAsXml.contains("<body class=\"topBarDisabled\">"));
 
         final String pageAsText = page.asNormalizedText();
         Assert.assertTrue(pageAsText.contains("Support for the HTTP and HTTPS protocols"));
@@ -84,8 +84,8 @@ public void submittingForm() throws Exception {
 @Test
 public void homePage_Firefox() throws Exception {
     try (final WebClient webClient = new WebClient(BrowserVersion.FIREFOX)) {
-        final HtmlPage page = webClient.getPage("http://htmlunit.sourceforge.net");
-        Assert.assertEquals("HtmlUnit - Welcome to HtmlUnit", page.getTitleText());
+        final HtmlPage page = webClient.getPage("https://htmlunit.sourceforge.io/");
+        Assert.assertEquals("HtmlUnit – Welcome to HtmlUnit", page.getTitleText());
     }
 }]]></source>
             <p>
@@ -158,13 +158,13 @@ public void getElements() throws Exception {
 @Test
 public void xpath() throws Exception {
     try (final WebClient webClient = new WebClient()) {
-        final HtmlPage page = webClient.getPage("http://htmlunit.sourceforge.net");
+        final HtmlPage page = webClient.getPage("https://htmlunit.sourceforge.io/");
 
         //get list of all divs
         final List<?> divs = page.getByXPath("//div");
 
-        //get div which has a 'name' attribute of 'John'
-        final HtmlDivision div = (HtmlDivision) page.getByXPath("//div[@name='John']").get(0);
+        //get div which has a 'id' attribute of 'banner'
+        final HtmlDivision div = (HtmlDivision) page.getByXPath("//div[@id='banner']").get(0);
     }
 }]]></source>
             </subsection>
@@ -177,7 +177,7 @@ public void xpath() throws Exception {
 @Test
 public void cssSelector() throws Exception {
     try (final WebClient webClient = new WebClient()) {
-        final HtmlPage page = webClient.getPage("http://htmlunit.sourceforge.net");
+        final HtmlPage page = webClient.getPage("https://htmlunit.sourceforge.io/");
 
         //get list of all divs
         final DomNodeList<DomNode> divs = page.querySelectorAll("div");


### PR DESCRIPTION
The samples targeting the HtmlUnit homepage do not match the current html markup.

I also updated the url because the old one returns a permanent redirect to https://htmlunit.sourceforge.io/.