### PR TITLE
Support Basic validation in HtmlEmailInput

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1168,6 +1168,9 @@
         <contributor>
             <name>Harald Albers</name>
         </contributor>
+        <contributor>
+            <name>Michael Lück</name>
+        </contributor>
     </contributors>
     <dependencies>
         <dependency>

--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlEmailInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlEmailInput.java
@@ -17,6 +17,7 @@ package com.gargoylesoftware.htmlunit.html;
 import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_INPUT_SET_VALUE_EMAIL_TRIMMED;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -31,9 +32,14 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  * @author Ronald Brill
  * @author Frank Danek
  * @author Anton Demydenko
+ * @author Michael Lück
  */
 public class HtmlEmailInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
+    // see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#validation
+    private static final Pattern DEFAULT_PATTERN = Pattern.compile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`\\{|\\}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$");
+
+    
     private SelectableTextSelectionDelegate selectionDelegate_ = new SelectableTextSelectionDelegate(this);
     private DoTypeProcessor doTypeProcessor_ = new DoTypeProcessor(this);
 
@@ -178,6 +184,16 @@ public class HtmlEmailInput extends HtmlInput implements SelectableTextInput, La
         newnode.doTypeProcessor_ = new DoTypeProcessor(newnode);
 
         return newnode;
+    }
+    
+
+    @Override
+    public boolean isValid() {
+        boolean isValid = super.isValid();
+        if(isValid && StringUtils.isNotBlank(getValueAttribute())) {
+            isValid &= DEFAULT_PATTERN.matcher(getValueAttribute()).matches(); 
+        }
+        return isValid; 
     }
 
     /**

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlEmailInput2Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlEmailInput2Test.java
@@ -25,6 +25,7 @@ import com.gargoylesoftware.htmlunit.junit.BrowserRunner;
  *
  * @author Ronald Brill
  * @author Anton Demydenko
+ * @author Michael Lück
  */
 @RunWith(BrowserRunner.class)
 public class HtmlEmailInput2Test extends SimpleWebTestCase {
@@ -123,6 +124,36 @@ public class HtmlEmailInput2Test extends SimpleWebTestCase {
         assertTrue(input.isValid());
         // invalid
         input.setValueAttribute("abc@eemail.com");
+        assertFalse(input.isValid());
+        // valid
+        input.setValueAttribute("abc@email.com");
+        assertTrue(input.isValid());
+    }
+    
+    /**
+     * Test should verify that even if there is no pattern
+     * the emailInput still validates the emailadress as browsers would do
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void basicValidation() throws Exception {
+        final String htmlContent
+            = "<html>\n"
+            + "<head></head>\n"
+            + "<body>\n"
+            + "<form id='form1'>\n"
+            + "  <input type='email' id='foo'>\n"
+            + "</form>\n"
+            + "</body></html>";
+
+        final HtmlPage page = loadPage(htmlContent);
+
+        final HtmlEmailInput input = (HtmlEmailInput) page.getElementById("foo");
+
+        // empty
+        assertTrue(input.isValid());
+        // invalid
+        input.setValueAttribute("abc");
         assertFalse(input.isValid());
         // valid
         input.setValueAttribute("abc@email.com");


### PR DESCRIPTION
the <input type="email" /> should support the validation of the value attribute even if
no pattern has  been specified (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#validation)

The implementation uses the regex defined in the MDN when the isValid method is called.
All other validations implemented in the super class take precedence.
The new regex validation takes place ONLY if the other validations would accept the input