### PR TITLE
Validation of decimal values min and step values in number input

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInput.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInput.java
@@ -18,6 +18,7 @@ import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_INPUT_NUMB
 import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_INPUT_NUMBER_DOT_AT_END_IS_DOUBLE;
 import static com.gargoylesoftware.htmlunit.BrowserVersionFeatures.JS_INPUT_SET_VALUE_MOVE_SELECTION_TO_START;
 
+import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
@@ -37,6 +38,7 @@ import com.gargoylesoftware.htmlunit.html.impl.SelectableTextSelectionDelegate;
  * @author Frank Danek
  * @author Anton Demydenko
  * @author Raik Bieniek
+ * @author Michael Lück
  */
 public class HtmlNumberInput extends HtmlInput implements SelectableTextInput, LabelableElement {
 
@@ -296,9 +298,9 @@ public class HtmlNumberInput extends HtmlInput implements SelectableTextInput, L
                 }
             }
 
-            final double value;
+            final BigDecimal value;
             try {
-                value = Double.parseDouble(valueAttr);
+                value = new BigDecimal(valueAttr);
             }
             catch (final NumberFormatException e) {
                 return false;
@@ -306,15 +308,15 @@ public class HtmlNumberInput extends HtmlInput implements SelectableTextInput, L
 
             if (!getMin().isEmpty()) {
                 try {
-                    final double min = Double.parseDouble(getMin());
-                    if (value < min) {
+                    final BigDecimal min = new BigDecimal(getMin());
+                    if (value.compareTo(min) < 0) {
                         return false;
                     }
 
                     if (!getStep().isEmpty()) {
                         try {
-                            final double step = Double.parseDouble(getStep());
-                            if (Math.abs((value - min) % step) > 0.000001d) {
+                            final BigDecimal step = new BigDecimal(getStep());
+                            if(value.remainder(step).doubleValue() > 0.0) {
                                 return false;
                             }
                         }
@@ -329,8 +331,8 @@ public class HtmlNumberInput extends HtmlInput implements SelectableTextInput, L
             }
             if (!getMax().isEmpty()) {
                 try {
-                    final double max = Double.parseDouble(getMax());
-                    if (value > max) {
+                    final BigDecimal max = new BigDecimal(getMax());
+                    if (value.compareTo(max) > 0) {
                         return false;
                     }
                 }

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInput2Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/HtmlNumberInput2Test.java
@@ -14,6 +14,8 @@
  */
 package com.gargoylesoftware.htmlunit.html;
 
+import static org.junit.Assert.fail;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,6 +28,7 @@ import com.gargoylesoftware.htmlunit.junit.BrowserRunner.Alerts;
  *
  * @author Ronald Brill
  * @author Anton Demydenko
+ * @author Michael Lück
  */
 @RunWith(BrowserRunner.class)
 public class HtmlNumberInput2Test extends SimpleWebTestCase {
@@ -159,6 +162,74 @@ public class HtmlNumberInput2Test extends SimpleWebTestCase {
         assertTrue(second.isValid());
         third.setValueAttribute("10");
         assertTrue(third.isValid());
+    }
+    
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void testMinValidationWithDecimalStepping() throws Exception {
+      
+        final String htmlContent = "<html>\n"
+                + "<head></head>\n"
+                + "<body>\n"
+                + "<form id='form1'>\n"
+                + "  <input type='number' id='first' min='0.5' step='0.1'>\n"
+                + "</form>\n"
+                + "</body></html>";
+
+        final HtmlPage page = loadPage(htmlContent);
+
+        final HtmlNumberInput first = (HtmlNumberInput) page.getElementById("first");
+
+        // empty
+        assertTrue(first.isValid());
+        // lesser
+        first.setValueAttribute("0.4");
+        assertFalse(first.isValid());
+        // equal
+        first.setValueAttribute("0.5");
+        assertTrue(first.isValid());
+        // bigger
+        first.setValueAttribute("0.6");
+        assertTrue(first.isValid());
+        // even bigger
+        first.setValueAttribute("1.6");
+        assertTrue(first.isValid());
+        // and even bigger again
+        first.setValueAttribute("2.1");
+        assertTrue(first.isValid());
+        // a lot bigger
+        first.setValueAttribute("10.8");
+        assertTrue(first.isValid());
+        // a lot bigger and insignificant decimal zeros
+        first.setValueAttribute("123456789.90");
+        assertTrue(first.isValid());
+        
+        //incorrect step
+        // a little bit different but still wroing
+        first.setValueAttribute("0.50000000000001");
+        assertFalse(first.isValid());
+        // still only little addition bit wrong nontheless
+        first.setValueAttribute("0.51");
+        assertFalse(first.isValid());
+        // even bigger
+        first.setValueAttribute("1.51");
+        assertFalse(first.isValid());
+        // and even bigger again
+        first.setValueAttribute("2.15");
+        assertFalse(first.isValid());
+        // a lot bigger
+        first.setValueAttribute("10.10001");
+        assertFalse(first.isValid());
+        // a lot bigger
+        first.setValueAttribute("123456789.1000001");
+        assertFalse(first.isValid());
+    }
+    
+    @Test
+    void testSteppingOnDefaultInsteadOfMin() {
+      fail("not yet implemented");
     }
 
     /**


### PR DESCRIPTION
previous validation logic used double as type for the min, max and step
values of the number input.
But that datatype has potential precision issues especially when using
remainder (modulo) operation on it
(see https://stackoverflow.com/questions/3227342/modulus-with-doubles-in-java)

So the datatype is switched to BigDecimal which allows for exact
remainder calculations