### PR TITLE
Execute js initialization jobs during html page initialization

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/TimeoutError.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/TimeoutError.java
@@ -35,7 +35,7 @@ public class TimeoutError extends Error {
      * Returns the allowed time.
      * @return the allowed time
      */
-    long getAllowedTime() {
+    public long getAllowedTime() {
         return allowedTime_;
     }
 
@@ -43,7 +43,7 @@ public class TimeoutError extends Error {
      * Returns the execution time.
      * @return the execution time
      */
-    long getExecutionTime() {
+    public long getExecutionTime() {
         return executionTime_;
     }
 }


### PR DESCRIPTION
Execute js jobs in html page before returning of WebClient.getPage(). This makes the ambiguous WebClient.waitForBackgroundJavaScriptXXXX() unnecessary in most cases. You can still wait for more jobs of course if needed. The page returned by WebClient.getPage() is now usually fully initialized and I think this is what users expect.