### PR TITLE
The caching algorithm should observe the max-age headers 

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/Cache.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/Cache.java
@@ -39,6 +39,7 @@ import com.gargoylesoftware.htmlunit.util.UrlUtils;
  * @author Ahmed Ashour
  * @author Anton Demydenko
  * @author Ronald Brill
+ * @author Ashley Frieze
  */
 public class Cache implements Serializable {
 
@@ -47,6 +48,9 @@ public class Cache implements Serializable {
 
     private static final Pattern DATE_HEADER_PATTERN = Pattern.compile("-?\\d+");
     static final long DELAY = 10 * org.apache.commons.lang3.time.DateUtils.MILLIS_PER_MINUTE;
+
+    // for taking ten percent of a number in milliseconds and converting that to the amount in seconds
+    private static final double TEN_PERCENT_OF_MILLISECONDS_IN_SECONDS = 0.0001;
 
     /**
      * The map which holds the cached responses. Note that when keying on URLs, we key on the string version
@@ -107,39 +111,56 @@ public class Cache implements Serializable {
         }
 
         /**
-         * <p>Check freshness return value if
-         * a) s-maxage specified
-         * b) max-age specified
-         * c) expired specified
-         * otherwise return {@code null}</p>
-         *
-         * @see <a href="https://tools.ietf.org/html/rfc7234">RFC 7234</a>
-         *
+         * Is this cached entry still fresh?
          * @param now the current time
-         * @return true if still fresh
+         * @return <code>true</code> if can keep in the cache
+         * @see {@link #isWithinCacheWindow(WebResponse, long, long)}
          */
         boolean isStillFresh(final long now) {
-            long freshnessLifetime = 0;
-            if (!HeaderUtils.containsPrivate(response_) && HeaderUtils.containsSMaxage(response_)) {
-                // check s-maxage
-                freshnessLifetime = HeaderUtils.sMaxage(response_);
-            }
-            else if (HeaderUtils.containsMaxAge(response_)) {
-                // check max-age
-                freshnessLifetime = HeaderUtils.maxAge(response_);
-            }
-            else if (response_.getResponseHeaderValue(HttpHeader.EXPIRES) == null) {
-                return true;
-            }
-            else {
-                final Date expires = parseDateHeader(response_, HttpHeader.EXPIRES);
-                if (expires != null) {
-                    // use the same logic as in isCacheableContent()
-                    return expires.getTime() - now > DELAY;
-                }
-            }
-            return now - createdAt_ < freshnessLifetime * org.apache.commons.lang3.time.DateUtils.MILLIS_PER_SECOND;
+            return Cache.isWithinCacheWindow(response_, now, createdAt_);
         }
+    }
+
+    /**
+     * <p>Find expiry time using
+     * a) s-maxage specified<br />
+     * b) max-age specified<br />
+     * c) expired specified<br />
+     * d) A Last-Update is specified and the time is now within 10% of the difference between download time and update
+     * time</p>
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7234#section-4.2.2">RFC 7234</a>
+     *
+     * @param response {@link WebResponse}
+     * @param now the current time
+     * @param createdAt when the request was downloaded
+     * @return true if still fresh
+     */
+    static boolean isWithinCacheWindow(final WebResponse response, final long now, final long createdAt) {
+        long freshnessLifetime = 0;
+        if (!HeaderUtils.containsPrivate(response) && HeaderUtils.containsSMaxage(response)) {
+            // check s-maxage
+            freshnessLifetime = HeaderUtils.sMaxage(response);
+        }
+        else if (HeaderUtils.containsMaxAge(response)) {
+            // check max-age
+            freshnessLifetime = HeaderUtils.maxAge(response);
+        }
+        else if (response.getResponseHeaderValue(HttpHeader.EXPIRES) != null) {
+            final Date expires = parseDateHeader(response, HttpHeader.EXPIRES);
+            if (expires != null) {
+                // use the same logic as in isCacheableContent()
+                return expires.getTime() - now > DELAY;
+            }
+        }
+        else if (response.getResponseHeaderValue(HttpHeader.LAST_MODIFIED) != null) {
+            final Date lastModified = parseDateHeader(response, HttpHeader.LAST_MODIFIED);
+            if (lastModified != null) {
+                freshnessLifetime = (long)(((double)createdAt - lastModified.getTime()) *
+                        TEN_PERCENT_OF_MILLISECONDS_IN_SECONDS);
+            }
+        }
+        return now - createdAt < freshnessLifetime * org.apache.commons.lang3.time.DateUtils.MILLIS_PER_SECOND;
     }
 
     /**
@@ -236,20 +257,8 @@ public class Cache implements Serializable {
             return false;
         }
 
-        final Date lastModified = parseDateHeader(response, HttpHeader.LAST_MODIFIED);
-
-        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires
-        // If there is a Cache-Control header with the max-age or s-maxage directive
-        // in the response, the Expires header is ignored.
-        Date expires = null;
-        if (!HeaderUtils.containsMaxAgeOrSMaxage(response)) {
-            expires = parseDateHeader(response, HttpHeader.EXPIRES);
-        }
-
         final long now = getCurrentTimestamp();
-
-        return expires != null && (expires.getTime() - now > DELAY)
-                || (expires == null && lastModified != null && now - lastModified.getTime() > DELAY);
+        return isWithinCacheWindow(response, now, now);
     }
 
     /**

--- a/src/test/java/com/gargoylesoftware/htmlunit/CacheTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/CacheTest.java
@@ -20,6 +20,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -50,49 +51,129 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
  * @author Frank Danek
  * @author Anton Demydenko
  * @author Ronald Brill
+ * @author Ashley Frieze
 */
 @RunWith(BrowserRunner.class)
 public class CacheTest extends SimpleWebTestCase {
 
+    private static final long ONE_MINUTE = 60_000L;
+    private static final long ONE_HOUR = ONE_MINUTE * 60;
+
+    private static final String EXPIRES_HEADER = "Expires";
+    private static final String CACHE_CONTROL_HEADER = "Cache-Control";
+    private static final String LAST_MODIFIED_HEADER = "Last-Modified";
+
+    private final long now = new Date().getTime();
+    private final String tomorrow = formatDate(DateUtils.addDays(new Date(), 1));
+
     /**
-     * Test.
+     * Composite test of {@link Cache#isCacheableContent(WebResponse)}
      */
     @Test
     public void isCacheableContent() {
         final Cache cache = new Cache();
         final Map<String, String> headers = new HashMap<>();
-        final WebResponse response = new DummyWebResponse() {
-            @Override
-            public String getResponseHeaderValue(final String headerName) {
-                return headers.get(headerName);
-            }
-        };
+        final WebResponse response = new HeaderResponse(headers);
 
         assertFalse(cache.isCacheableContent(response));
 
-        headers.put("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT");
+        headers.put(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT");
         assertTrue(cache.isCacheableContent(response));
 
-        headers.put("Last-Modified", formatDate(DateUtils.addMinutes(new Date(), -5)));
-        assertFalse(cache.isCacheableContent(response));
-
-        headers.put("Expires", formatDate(DateUtils.addMinutes(new Date(), 5)));
-        assertFalse(cache.isCacheableContent(response));
-
-        headers.put("Expires", formatDate(DateUtils.addHours(new Date(), 1)));
+        headers.put(LAST_MODIFIED_HEADER, formatDate(DateUtils.addMinutes(new Date(), -5)));
         assertTrue(cache.isCacheableContent(response));
 
-        headers.remove("Last-Modified");
+        headers.put(LAST_MODIFIED_HEADER, formatDate(new Date()));
+        assertFalse(cache.isCacheableContent(response));
+
+        headers.put(LAST_MODIFIED_HEADER, formatDate(DateUtils.addMinutes(new Date(), 10)));
+        assertFalse(cache.isCacheableContent(response));
+
+        headers.put(EXPIRES_HEADER, formatDate(DateUtils.addMinutes(new Date(), 5)));
+        assertFalse(cache.isCacheableContent(response));
+
+        headers.put(EXPIRES_HEADER, formatDate(DateUtils.addHours(new Date(), 1)));
         assertTrue(cache.isCacheableContent(response));
 
-        headers.put("Expires", "0");
+        headers.remove(LAST_MODIFIED_HEADER);
+        assertTrue(cache.isCacheableContent(response));
+
+        headers.put(EXPIRES_HEADER, "0");
         assertFalse(cache.isCacheableContent(response));
 
-        headers.put("Expires", "-1");
+        headers.put(EXPIRES_HEADER, "-1");
         assertFalse(cache.isCacheableContent(response));
 
-        headers.put("Cache-Control", "no-store");
+        headers.put(CACHE_CONTROL_HEADER, "no-store");
         assertFalse(cache.isCacheableContent(response));
+    }
+
+    @Test
+    public void contentWithNoHeadersIsNotCached() {
+        assertFalse(Cache.isWithinCacheWindow(new HeaderResponse(), now, now));
+    }
+
+    @Test
+    public void contentWithExpiryDateIsCached() {
+        assertTrue(Cache.isWithinCacheWindow(new HeaderResponse(EXPIRES_HEADER, tomorrow),
+                now, now));
+    }
+
+    @Test
+    public void contentWithExpiryDateInFutureButShortMaxAgeIsNotInCacheWindow() {
+        // max age is 1 second, so will have expired after a minute
+        assertFalse(Cache.isWithinCacheWindow(new HeaderResponse(
+                EXPIRES_HEADER, tomorrow,
+                        CACHE_CONTROL_HEADER, "some-other-value, max-age=1"),
+                now + ONE_MINUTE, now));
+    }
+
+    @Test
+    public void contentWithExpiryDateInFutureButShortSMaxAgeIsNotInCacheWindow() {
+        // s max age is 1 second, so will have expired after a minute
+        assertFalse(Cache.isWithinCacheWindow(new HeaderResponse(
+                        EXPIRES_HEADER, tomorrow,
+                        CACHE_CONTROL_HEADER, "some-other-value, s-maxage=1"),
+                now + ONE_MINUTE, now));
+    }
+
+    @Test
+    public void contentWithBothMaxAgeAndSMaxUsesSMaxAsPriority() {
+        assertFalse(Cache.isWithinCacheWindow(new HeaderResponse(
+                        CACHE_CONTROL_HEADER, "some-other-value, max-age=1200, s-maxage=1"),
+                now + ONE_MINUTE, now));
+    }
+
+    @Test
+    public void contentWithMaxAgeInFutureWillBeCached() {
+        assertTrue(Cache.isWithinCacheWindow(new HeaderResponse(
+                        CACHE_CONTROL_HEADER, "some-other-value, max-age=1200"),
+                now, now));
+
+        assertTrue(Cache.isWithinCacheWindow(new HeaderResponse(
+                        CACHE_CONTROL_HEADER, "some-other-value, max-age=1200"),
+                now + ONE_MINUTE, now));
+    }
+
+    @Test
+    public void contentWithLongLastModifiedTimeComparedToNowIsCachedOnDownload() {
+        assertTrue(Cache.isWithinCacheWindow(new HeaderResponse(
+                        LAST_MODIFIED_HEADER, formatDate(DateUtils.addDays(new Date(), -1))),
+                now, now));
+    }
+
+    @Test
+    public void contentWithLastModifiedTimeIsCachedAfterAFewPercentOfCreationAge() {
+        assertTrue(Cache.isWithinCacheWindow(new HeaderResponse(
+                        LAST_MODIFIED_HEADER, formatDate(DateUtils.addDays(new Date(), -1))),
+                now + ONE_HOUR, now));
+    }
+
+    @Test
+    public void contentWithLastModifiedTimeIsNotCachedAfterALongerPeriod() {
+        assertFalse(Cache.isWithinCacheWindow(new HeaderResponse(
+                        LAST_MODIFIED_HEADER, formatDate(DateUtils.addDays(new Date(), -1))),
+                now + (ONE_HOUR * 5), now));
     }
 
     /**
@@ -126,7 +207,7 @@ public class CacheTest extends SimpleWebTestCase {
         connection.setResponse(urlPage2, content2);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT"));
+        headers.add(new NameValuePair(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT"));
         connection.setResponse(new URL(URL_FIRST, "foo1.js"), script1, 200, "ok",
                 MimeType.APPLICATION_JAVASCRIPT, headers);
         connection.setResponse(new URL(URL_FIRST, "foo2.js"), script2, 200, "ok",
@@ -182,7 +263,7 @@ public class CacheTest extends SimpleWebTestCase {
         getMockWebConnection().setResponse(urlPage2, content2);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT"));
+        headers.add(new NameValuePair(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT"));
         getMockWebConnection().setResponse(new URL(URL_FIRST, "foo1.js"), script1,
                 200, "ok", MimeType.APPLICATION_JAVASCRIPT, headers);
         getMockWebConnection().setDefaultResponse(script2, 200, "ok", MimeType.APPLICATION_JAVASCRIPT, headers);
@@ -250,7 +331,7 @@ public class CacheTest extends SimpleWebTestCase {
         getMockWebConnection().setResponse(urlPage2, content2);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT"));
+        headers.add(new NameValuePair(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT"));
         getMockWebConnection().setResponse(new URL(URL_FIRST, "foo1.js"), "",
                 200, "ok", MimeType.TEXT_CSS, headers);
         getMockWebConnection().setDefaultResponse("", 200, "ok", MimeType.TEXT_CSS, headers);
@@ -294,7 +375,7 @@ public class CacheTest extends SimpleWebTestCase {
         connection.setResponse(pageUrl, html);
 
         final List<NameValuePair> headers =
-            Collections.singletonList(new NameValuePair("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT"));
+            Collections.singletonList(new NameValuePair(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT"));
         connection.setResponse(new URL(URL_FIRST, "foo1.js"), ";", 200, "ok", MimeType.APPLICATION_JAVASCRIPT, headers);
         connection.setResponse(new URL(URL_FIRST, "foo2.js"), ";", 200, "ok", MimeType.APPLICATION_JAVASCRIPT, headers);
 
@@ -327,7 +408,7 @@ public class CacheTest extends SimpleWebTestCase {
         connection.setResponse(pageUrl, html);
 
         final List<NameValuePair> headers =
-            Collections.singletonList(new NameValuePair("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT"));
+            Collections.singletonList(new NameValuePair(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT"));
         connection.setResponse(new URL(URL_FIRST, "foo.css"), "", 200, "OK", MimeType.TEXT_CSS, headers);
 
         client.getPage(pageUrl);
@@ -364,7 +445,7 @@ public class CacheTest extends SimpleWebTestCase {
         headers.add(new NameValuePair("Location", redirectUrl.toExternalForm()));
         connection.setResponse(cssUrl, "", 301, "Redirect", null, headers);
 
-        headers = Collections.singletonList(new NameValuePair("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT"));
+        headers = Collections.singletonList(new NameValuePair(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT"));
         connection.setResponse(redirectUrl, css, 200, "OK", MimeType.TEXT_CSS, headers);
 
         client.getPage(pageUrl);
@@ -401,7 +482,7 @@ public class CacheTest extends SimpleWebTestCase {
         final MockWebConnection connection = getMockWebConnection();
 
         final List<NameValuePair> headers =
-            Collections.singletonList(new NameValuePair("Last-Modified", "Sun, 15 Jul 2007 20:46:27 GMT"));
+            Collections.singletonList(new NameValuePair(LAST_MODIFIED_HEADER, "Sun, 15 Jul 2007 20:46:27 GMT"));
         connection.setResponse(new URL(URL_FIRST, "foo.txt"), "hello", 200, "OK", MimeType.TEXT_PLAIN, headers);
 
         loadPageWithAlerts(html);
@@ -426,7 +507,7 @@ public class CacheTest extends SimpleWebTestCase {
         client.setWebConnection(connection);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Cache-Control", "some-other-value, no-store"));
+        headers.add(new NameValuePair(CACHE_CONTROL_HEADER, "some-other-value, no-store"));
 
         final URL pageUrl = new URL(URL_FIRST, "page1.html");
         connection.setResponse(pageUrl, html, 200, "OK", "text/html;charset=ISO-8859-1", headers);
@@ -458,8 +539,8 @@ public class CacheTest extends SimpleWebTestCase {
         client.setWebConnection(connection);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Last-Modified", "Tue, 20 Feb 2018 10:00:00 GMT"));
-        headers.add(new NameValuePair("Cache-Control", "some-other-value, max-age=1"));
+        headers.add(new NameValuePair(LAST_MODIFIED_HEADER, "Tue, 20 Feb 2018 10:00:00 GMT"));
+        headers.add(new NameValuePair(CACHE_CONTROL_HEADER, "some-other-value, max-age=1"));
 
         final URL pageUrl = new URL(URL_FIRST, "page1.html");
         connection.setResponse(pageUrl, html, 200, "OK", "text/html;charset=ISO-8859-1", headers);
@@ -502,8 +583,8 @@ public class CacheTest extends SimpleWebTestCase {
         client.setWebConnection(connection);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Last-Modified", "Tue, 20 Feb 2018 10:00:00 GMT"));
-        headers.add(new NameValuePair("Cache-Control", "public, s-maxage=1, some-other-value, max-age=10"));
+        headers.add(new NameValuePair(LAST_MODIFIED_HEADER, "Tue, 20 Feb 2018 10:00:00 GMT"));
+        headers.add(new NameValuePair(CACHE_CONTROL_HEADER, "public, s-maxage=1, some-other-value, max-age=10"));
 
         final URL pageUrl = new URL(URL_FIRST, "page1.html");
         connection.setResponse(pageUrl, html, 200, "OK", "text/html;charset=ISO-8859-1", headers);
@@ -546,10 +627,10 @@ public class CacheTest extends SimpleWebTestCase {
         client.setWebConnection(connection);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Last-Modified", "Tue, 20 Feb 2018 10:00:00 GMT"));
-        headers.add(new NameValuePair("Expires", new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz").format(new Date(
+        headers.add(new NameValuePair(LAST_MODIFIED_HEADER, "Tue, 20 Feb 2018 10:00:00 GMT"));
+        headers.add(new NameValuePair(EXPIRES_HEADER, new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz").format(new Date(
             System.currentTimeMillis() + 2 * 1000 + 10 * org.apache.commons.lang3.time.DateUtils.MILLIS_PER_MINUTE))));
-        headers.add(new NameValuePair("Cache-Control", "public, some-other-value"));
+        headers.add(new NameValuePair(CACHE_CONTROL_HEADER, "public, some-other-value"));
 
         final URL pageUrl = new URL(URL_FIRST, "page1.html");
         connection.setResponse(pageUrl, html, 200, "OK", "text/html;charset=ISO-8859-1", headers);
@@ -586,9 +667,9 @@ public class CacheTest extends SimpleWebTestCase {
         client.setWebConnection(connection);
 
         final List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new NameValuePair("Last-Modified", "Tue, 20 Feb 2018 10:00:00 GMT"));
-        headers.add(new NameValuePair("Expires", "0"));
-        headers.add(new NameValuePair("Cache-Control", "max-age=20"));
+        headers.add(new NameValuePair(LAST_MODIFIED_HEADER, "Tue, 20 Feb 2018 10:00:00 GMT"));
+        headers.add(new NameValuePair(EXPIRES_HEADER, "0"));
+        headers.add(new NameValuePair(CACHE_CONTROL_HEADER, "max-age=20"));
 
         final URL pageUrl = new URL(URL_FIRST, "page1.html");
         connection.setResponse(pageUrl, html, 200, "OK", "text/html;charset=ISO-8859-1", headers);
@@ -615,7 +696,10 @@ public class CacheTest extends SimpleWebTestCase {
         expectLastCall().atLeastOnce();
         expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
         expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
-        expect(response1.getResponseHeaderValue(HttpHeader.LAST_MODIFIED)).andReturn(null);
+        expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
+        expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
+        expect(response1.getResponseHeaderValue(HttpHeader.EXPIRES)).andReturn(
+                formatDate(DateUtils.addHours(new Date(), 1)));
         expect(response1.getResponseHeaderValue(HttpHeader.EXPIRES)).andReturn(
                 formatDate(DateUtils.addHours(new Date(), 1)));
 
@@ -625,7 +709,10 @@ public class CacheTest extends SimpleWebTestCase {
         expectLastCall().atLeastOnce();
         expect(response2.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
         expect(response2.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
-        expect(response2.getResponseHeaderValue(HttpHeader.LAST_MODIFIED)).andReturn(null);
+        expect(response2.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
+        expect(response2.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
+        expect(response2.getResponseHeaderValue(HttpHeader.EXPIRES)).andReturn(
+                formatDate(DateUtils.addHours(new Date(), 1)));
         expect(response2.getResponseHeaderValue(HttpHeader.EXPIRES)).andReturn(
                 formatDate(DateUtils.addHours(new Date(), 1)));
 
@@ -653,7 +740,10 @@ public class CacheTest extends SimpleWebTestCase {
         expectLastCall().atLeastOnce();
         expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
         expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
-        expect(response1.getResponseHeaderValue(HttpHeader.LAST_MODIFIED)).andReturn(null);
+        expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
+        expect(response1.getResponseHeaderValue(HttpHeader.CACHE_CONTROL)).andReturn(null);
+        expect(response1.getResponseHeaderValue(HttpHeader.EXPIRES)).andReturn(
+                formatDate(DateUtils.addHours(new Date(), 1)));
         expect(response1.getResponseHeaderValue(HttpHeader.EXPIRES)).andReturn(
                 formatDate(DateUtils.addHours(new Date(), 1)));
 
@@ -729,5 +819,26 @@ class DummyWebResponse extends WebResponse {
     @Override
     public WebRequest getWebRequest() {
         throw new RuntimeException("not implemented");
+    }
+}
+
+class HeaderResponse extends DummyWebResponse {
+    private Map<String, String> headers_;
+
+    public HeaderResponse(Map<String, String> headers) {
+        this.headers_ = headers;
+    }
+
+    public HeaderResponse(String ... headers) {
+        assertTrue(headers.length % 2 == 0);
+        headers_ = new HashMap<>();
+        for (int i = 0; i < headers.length; i += 2) {
+            headers_.put(headers[i], headers[i + 1]);
+        }
+    }
+
+    @Override
+    public String getResponseHeaderValue(String headerName) {
+        return headers_.get(headerName);
     }
 }


### PR DESCRIPTION
This is the foremost priority, dropping back to `Last-Modified` with a heuristic as per RFC7234

This replaces the behaviour where the max-age headers were not considered at the time of caching, and where very recently `Last-Modified` pages were NOT allowed in the cache either way.

This change introduces some additional tests, with some test refactoring to avoid too many repeated constants.

It also centralises the logic for eviction and ingress into the cache.

It's a potential fix for #432 