### PR TITLE
Rename Method as part of Refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1176,6 +1176,9 @@
         <contributor>
             <name>Ashley Frieze</name>
         </contributor>
+        <contributor>
+            <name>Bharatwaaj Shankaranarayanan</name>
+        </contributor>
     </contributors>
     <dependencies>
         <dependency>

--- a/src/main/java/com/gargoylesoftware/htmlunit/css/CssStyleSheet.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/css/CssStyleSheet.java
@@ -353,8 +353,8 @@ public class CssStyleSheet implements Serializable {
      * @param fromQuerySelectorAll whether this is called from {@link DomNode#querySelectorAll(String)}
      * @return {@code true} if it does apply, {@code false} if it doesn't apply
      */
-    public static boolean selects(final BrowserVersion browserVersion, final Selector selector,
-            final DomElement element, final String pseudoElement, final boolean fromQuerySelectorAll) {
+    public static boolean selectsSpecifiedElement(final BrowserVersion browserVersion, final Selector selector,
+                                                  final DomElement element, final String pseudoElement, final boolean fromQuerySelectorAll) {
         switch (selector.getSelectorType()) {
             case ELEMENT_NODE_SELECTOR:
                 final ElementSelector es = (ElementSelector) selector;
@@ -374,7 +374,7 @@ public class CssStyleSheet implements Serializable {
                     final List<Condition> conditions = es.getConditions();
                     if (conditions != null) {
                         for (final Condition condition : conditions) {
-                            if (!selects(browserVersion, condition, element, fromQuerySelectorAll)) {
+                            if (!selectsSpecifiedElement(browserVersion, condition, element, fromQuerySelectorAll)) {
                                 return false;
                             }
                         }
@@ -393,21 +393,21 @@ public class CssStyleSheet implements Serializable {
                     return false; // for instance parent is a DocumentFragment
                 }
                 final ChildSelector cs = (ChildSelector) selector;
-                return selects(browserVersion, cs.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)
-                    && selects(browserVersion, cs.getAncestorSelector(), (DomElement) parentNode,
+                return selectsSpecifiedElement(browserVersion, cs.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)
+                    && selectsSpecifiedElement(browserVersion, cs.getAncestorSelector(), (DomElement) parentNode,
                             pseudoElement, fromQuerySelectorAll);
 
             case DESCENDANT_SELECTOR:
                 final DescendantSelector ds = (DescendantSelector) selector;
                 final SimpleSelector simpleSelector = ds.getSimpleSelector();
-                if (selects(browserVersion, simpleSelector, element, pseudoElement, fromQuerySelectorAll)) {
+                if (selectsSpecifiedElement(browserVersion, simpleSelector, element, pseudoElement, fromQuerySelectorAll)) {
                     DomNode ancestor = element;
                     if (simpleSelector.getSelectorType() != SelectorType.PSEUDO_ELEMENT_SELECTOR) {
                         ancestor = ancestor.getParentNode();
                     }
                     final Selector dsAncestorSelector = ds.getAncestorSelector();
                     while (ancestor instanceof DomElement) {
-                        if (selects(browserVersion, dsAncestorSelector, (DomElement) ancestor, pseudoElement,
+                        if (selectsSpecifiedElement(browserVersion, dsAncestorSelector, (DomElement) ancestor, pseudoElement,
                                 fromQuerySelectorAll)) {
                             return true;
                         }
@@ -418,24 +418,24 @@ public class CssStyleSheet implements Serializable {
 
             case DIRECT_ADJACENT_SELECTOR:
                 final DirectAdjacentSelector das = (DirectAdjacentSelector) selector;
-                if (selects(browserVersion, das.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
+                if (selectsSpecifiedElement(browserVersion, das.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
                     DomNode prev = element.getPreviousSibling();
                     while (prev != null && !(prev instanceof DomElement)) {
                         prev = prev.getPreviousSibling();
                     }
                     return prev != null
-                            && selects(browserVersion, das.getSelector(),
+                            && selectsSpecifiedElement(browserVersion, das.getSelector(),
                                     (DomElement) prev, pseudoElement, fromQuerySelectorAll);
                 }
                 return false;
 
             case GENERAL_ADJACENT_SELECTOR:
                 final GeneralAdjacentSelector gas = (GeneralAdjacentSelector) selector;
-                if (selects(browserVersion, gas.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
+                if (selectsSpecifiedElement(browserVersion, gas.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
                     for (DomNode prev1 = element.getPreviousSibling(); prev1 != null;
                                                         prev1 = prev1.getPreviousSibling()) {
                         if (prev1 instanceof DomElement
-                            && selects(browserVersion, gas.getSelector(), (DomElement) prev1,
+                            && selectsSpecifiedElement(browserVersion, gas.getSelector(), (DomElement) prev1,
                                     pseudoElement, fromQuerySelectorAll)) {
                             return true;
                         }
@@ -464,13 +464,13 @@ public class CssStyleSheet implements Serializable {
      * @param browserVersion the browser version
      * @param condition the condition to test
      * @param element the element to test
-     * @param fromQuerySelectorAll whether this is called from {@link DomNode#querySelectorAll(String)}
+     * @param fromQuerySelectorAll whether this is called from {@link DomNode#querySelectorAll(String)
      * @return {@code true} if it does apply, {@code false} if it doesn't apply
      */
     // TODO make (package) private again
-    public static boolean selects(final BrowserVersion browserVersion,
-            final Condition condition, final DomElement element,
-            final boolean fromQuerySelectorAll) {
+    public static boolean selectsSpecifiedElement(final BrowserVersion browserVersion,
+                                                  final Condition condition, final DomElement element,
+                                                  final boolean fromQuerySelectorAll) {
 
         switch (condition.getConditionType()) {
             case ID_CONDITION:
@@ -511,14 +511,14 @@ public class CssStyleSheet implements Serializable {
                         && element.getAttribute(condition.getLocalName()).contains(substringValue);
 
             case BEGIN_HYPHEN_ATTRIBUTE_CONDITION:
-                final String v = condition.getValue();
-                final String a = element.getAttribute(condition.getLocalName());
-                return selectsHyphenSeparated(v, a);
+                final String beginHyphenAttributeValue = condition.getValue();
+                final String attribute = element.getAttribute(condition.getLocalName());
+                return selectsHyphenSeparated(beginHyphenAttributeValue, attribute);
 
             case ONE_OF_ATTRIBUTE_CONDITION:
-                final String v2 = condition.getValue();
-                final String a2 = element.getAttribute(condition.getLocalName());
-                return selectsOneOf(v2, a2);
+                final String oneOfAttributeCondition = condition.getValue();
+                final String attributeOneoOfAttribute = element.getAttribute(condition.getLocalName());
+                return selectsOneOf(oneOfAttributeCondition, attributeOneoOfAttribute);
 
             case LANG_CONDITION:
                 final String lcLang = condition.getValue();
@@ -831,7 +831,7 @@ public class CssStyleSheet implements Serializable {
 
                         validateSelectors(selectorList, 9, element);
 
-                        return !selects(browserVersion, selectorList.get(0), element,
+                        return !selectsSpecifiedElement(browserVersion, selectorList.get(0), element,
                                 null, fromQuerySelectorAll);
                     }
                     catch (final IOException e) {

--- a/src/main/java/com/gargoylesoftware/htmlunit/css/CssStyleSheet.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/css/CssStyleSheet.java
@@ -852,7 +852,7 @@ public class CssStyleSheet implements Serializable {
         return true;
     }
 
-    private static boolean getNth(final String nth, final int index) {
+    private static boolean getNthElement(final String nth, final int index) {
         if ("odd".equalsIgnoreCase(nth)) {
             return index % 2 != 0;
         }
@@ -861,19 +861,19 @@ public class CssStyleSheet implements Serializable {
             return index % 2 == 0;
         }
 
-        // an+b
+        // (numerator) * n + (denominator)
         final int nIndex = nth.indexOf('n');
-        int a = 0;
+        int denominator = 0;
         if (nIndex != -1) {
             String value = nth.substring(0, nIndex).trim();
             if ("-".equals(value)) {
-                a = -1;
+                denominator = -1;
             }
             else {
                 if (value.length() > 0 && value.charAt(0) == '+') {
                     value = value.substring(1);
                 }
-                a = NumberUtils.toInt(value, 1);
+                denominator = NumberUtils.toInt(value, 1);
             }
         }
 
@@ -881,12 +881,12 @@ public class CssStyleSheet implements Serializable {
         if (value.length() > 0 && value.charAt(0) == '+') {
             value = value.substring(1);
         }
-        final int b = NumberUtils.toInt(value, 0);
-        if (a == 0) {
-            return index == b && b > 0;
+        final int numerator = NumberUtils.toInt(value, 0);
+        if (denominator == 0) {
+            return index == numerator && numerator > 0;
         }
 
-        final double n = (index - b) / (double) a;
+        final double n = (index - numerator) / (double) denominator;
         return n >= 0 && n % 1 == 0;
     }
 

--- a/src/main/java/com/gargoylesoftware/htmlunit/css/CssStyleSheet.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/css/CssStyleSheet.java
@@ -353,8 +353,8 @@ public class CssStyleSheet implements Serializable {
      * @param fromQuerySelectorAll whether this is called from {@link DomNode#querySelectorAll(String)}
      * @return {@code true} if it does apply, {@code false} if it doesn't apply
      */
-    public static boolean selectsSpecifiedElement(final BrowserVersion browserVersion, final Selector selector,
-                                                  final DomElement element, final String pseudoElement, final boolean fromQuerySelectorAll) {
+    public static boolean selects(final BrowserVersion browserVersion, final Selector selector,
+            final DomElement element, final String pseudoElement, final boolean fromQuerySelectorAll) {
         switch (selector.getSelectorType()) {
             case ELEMENT_NODE_SELECTOR:
                 final ElementSelector es = (ElementSelector) selector;
@@ -374,7 +374,7 @@ public class CssStyleSheet implements Serializable {
                     final List<Condition> conditions = es.getConditions();
                     if (conditions != null) {
                         for (final Condition condition : conditions) {
-                            if (!selectsSpecifiedElement(browserVersion, condition, element, fromQuerySelectorAll)) {
+                            if (!selects(browserVersion, condition, element, fromQuerySelectorAll)) {
                                 return false;
                             }
                         }
@@ -393,21 +393,21 @@ public class CssStyleSheet implements Serializable {
                     return false; // for instance parent is a DocumentFragment
                 }
                 final ChildSelector cs = (ChildSelector) selector;
-                return selectsSpecifiedElement(browserVersion, cs.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)
-                    && selectsSpecifiedElement(browserVersion, cs.getAncestorSelector(), (DomElement) parentNode,
+                return selects(browserVersion, cs.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)
+                    && selects(browserVersion, cs.getAncestorSelector(), (DomElement) parentNode,
                             pseudoElement, fromQuerySelectorAll);
 
             case DESCENDANT_SELECTOR:
                 final DescendantSelector ds = (DescendantSelector) selector;
                 final SimpleSelector simpleSelector = ds.getSimpleSelector();
-                if (selectsSpecifiedElement(browserVersion, simpleSelector, element, pseudoElement, fromQuerySelectorAll)) {
+                if (selects(browserVersion, simpleSelector, element, pseudoElement, fromQuerySelectorAll)) {
                     DomNode ancestor = element;
                     if (simpleSelector.getSelectorType() != SelectorType.PSEUDO_ELEMENT_SELECTOR) {
                         ancestor = ancestor.getParentNode();
                     }
                     final Selector dsAncestorSelector = ds.getAncestorSelector();
                     while (ancestor instanceof DomElement) {
-                        if (selectsSpecifiedElement(browserVersion, dsAncestorSelector, (DomElement) ancestor, pseudoElement,
+                        if (selects(browserVersion, dsAncestorSelector, (DomElement) ancestor, pseudoElement,
                                 fromQuerySelectorAll)) {
                             return true;
                         }
@@ -418,24 +418,24 @@ public class CssStyleSheet implements Serializable {
 
             case DIRECT_ADJACENT_SELECTOR:
                 final DirectAdjacentSelector das = (DirectAdjacentSelector) selector;
-                if (selectsSpecifiedElement(browserVersion, das.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
+                if (selects(browserVersion, das.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
                     DomNode prev = element.getPreviousSibling();
                     while (prev != null && !(prev instanceof DomElement)) {
                         prev = prev.getPreviousSibling();
                     }
                     return prev != null
-                            && selectsSpecifiedElement(browserVersion, das.getSelector(),
+                            && selects(browserVersion, das.getSelector(),
                                     (DomElement) prev, pseudoElement, fromQuerySelectorAll);
                 }
                 return false;
 
             case GENERAL_ADJACENT_SELECTOR:
                 final GeneralAdjacentSelector gas = (GeneralAdjacentSelector) selector;
-                if (selectsSpecifiedElement(browserVersion, gas.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
+                if (selects(browserVersion, gas.getSimpleSelector(), element, pseudoElement, fromQuerySelectorAll)) {
                     for (DomNode prev1 = element.getPreviousSibling(); prev1 != null;
                                                         prev1 = prev1.getPreviousSibling()) {
                         if (prev1 instanceof DomElement
-                            && selectsSpecifiedElement(browserVersion, gas.getSelector(), (DomElement) prev1,
+                            && selects(browserVersion, gas.getSelector(), (DomElement) prev1,
                                     pseudoElement, fromQuerySelectorAll)) {
                             return true;
                         }
@@ -464,13 +464,13 @@ public class CssStyleSheet implements Serializable {
      * @param browserVersion the browser version
      * @param condition the condition to test
      * @param element the element to test
-     * @param fromQuerySelectorAll whether this is called from {@link DomNode#querySelectorAll(String)
+     * @param fromQuerySelectorAll whether this is called from {@link DomNode#querySelectorAll(String)}
      * @return {@code true} if it does apply, {@code false} if it doesn't apply
      */
     // TODO make (package) private again
-    public static boolean selectsSpecifiedElement(final BrowserVersion browserVersion,
-                                                  final Condition condition, final DomElement element,
-                                                  final boolean fromQuerySelectorAll) {
+    public static boolean selects(final BrowserVersion browserVersion,
+            final Condition condition, final DomElement element,
+            final boolean fromQuerySelectorAll) {
 
         switch (condition.getConditionType()) {
             case ID_CONDITION:
@@ -511,14 +511,14 @@ public class CssStyleSheet implements Serializable {
                         && element.getAttribute(condition.getLocalName()).contains(substringValue);
 
             case BEGIN_HYPHEN_ATTRIBUTE_CONDITION:
-                final String beginHyphenAttributeValue = condition.getValue();
-                final String attribute = element.getAttribute(condition.getLocalName());
-                return selectsHyphenSeparated(beginHyphenAttributeValue, attribute);
+                final String v = condition.getValue();
+                final String a = element.getAttribute(condition.getLocalName());
+                return selectsHyphenSeparated(v, a);
 
             case ONE_OF_ATTRIBUTE_CONDITION:
-                final String oneOfAttributeCondition = condition.getValue();
-                final String attributeOneoOfAttribute = element.getAttribute(condition.getLocalName());
-                return selectsOneOf(oneOfAttributeCondition, attributeOneoOfAttribute);
+                final String v2 = condition.getValue();
+                final String a2 = element.getAttribute(condition.getLocalName());
+                return selectsOneOf(v2, a2);
 
             case LANG_CONDITION:
                 final String lcLang = condition.getValue();
@@ -831,7 +831,7 @@ public class CssStyleSheet implements Serializable {
 
                         validateSelectors(selectorList, 9, element);
 
-                        return !selectsSpecifiedElement(browserVersion, selectorList.get(0), element,
+                        return !selects(browserVersion, selectorList.get(0), element,
                                 null, fromQuerySelectorAll);
                     }
                     catch (final IOException e) {


### PR DESCRIPTION
<h1>Refactoring: Rename Method</h1> 

<h3> Reason for change: </h3>
The method selects a specified element based on the parameterized condition. So, the function name must be clearly mentioned as selectSpecifiedElement rather than just selects.

&nbsp;
**From** select
**To** selectSpecifiedElement

&nbsp;

Particulars | Details | Comments
-- | -- | --
Commit Hash | com.gargoylesoftware.htmlunit |  
Branch Name | asdc-assignment-set-1-extract-method |  
Branch Link | https://github.com/bharatwaaj/htmlunit/tree/asdc-assignment-set-1-rename-method |  
PR URL | https://github.com/HtmlUnit/htmlunit/pull/465 |  