### PR TITLE
Refactoring: Pull-up Field

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMDocumentType.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMDocumentType.java
@@ -35,8 +35,6 @@ import net.sourceforge.htmlunit.corejs.javascript.Context;
 @JsxClass(domClass = DomDocumentType.class, value = IE)
 public class XMLDOMDocumentType extends XMLDOMNode {
 
-    private XMLDOMNamedNodeMap attributes_;
-
     /**
      * Returns the list of attributes for this element.
      * @return the list of attributes for this element

--- a/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMElement.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMElement.java
@@ -49,7 +49,6 @@ import net.sourceforge.htmlunit.corejs.javascript.Context;
 @JsxClass(domClass = DomElement.class, value = IE)
 public class XMLDOMElement extends XMLDOMNode {
 
-    private XMLDOMNamedNodeMap attributes_;
     private Map<String, XMLDOMNodeList> elementsByTagName_; // for performance and for equality (==)
 
     /**

--- a/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMNode.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMNode.java
@@ -60,6 +60,9 @@ public class XMLDOMNode extends MSXMLScriptable {
 
     /** "Live" child nodes collection; has to be a member to have equality (==) working. */
     private XMLDOMNodeList childNodes_;
+    
+    
+    protected XMLDOMNamedNodeMap attributes_;
 
     /**
      * Returns the list of attributes for this node.

--- a/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMProcessingInstruction.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/activex/javascript/msxml/XMLDOMProcessingInstruction.java
@@ -38,7 +38,6 @@ public final class XMLDOMProcessingInstruction extends XMLDOMNode {
     private static final String XML_DECLARATION_TARGET = "xml";
 
     private boolean attributesComputed_;
-    private XMLDOMNamedNodeMap attributes_;
 
     /**
      * Returns the list of attributes for this element.


### PR DESCRIPTION
<h1>Refactoring: Pull-up Field</h1> 

<h3> Reason for change: </h3>
The attributes field is used in almost most of the complex sub classes that associates and follows the superclass XMLDomNode and thus it has a good scope to be pulled up. There is also an empty getAttributes in the super class, which could be enhanced later, if this field is pulled up.

&nbsp;