### PR TITLE
HtmlUnitNekoDOMBuilder: Better handling of <form></form> enclosures

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
@@ -33,13 +33,6 @@ import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
-import net.sourceforge.htmlunit.xerces.parsers.AbstractSAXParser;
-import net.sourceforge.htmlunit.xerces.xni.Augmentations;
-import net.sourceforge.htmlunit.xerces.xni.QName;
-import net.sourceforge.htmlunit.xerces.xni.XMLAttributes;
-import net.sourceforge.htmlunit.xerces.xni.XNIException;
-import net.sourceforge.htmlunit.xerces.xni.parser.XMLInputSource;
-import net.sourceforge.htmlunit.xerces.xni.parser.XMLParserConfiguration;
 import org.w3c.dom.Node;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -82,6 +75,13 @@ import net.sourceforge.htmlunit.cyberneko.HTMLElements;
 import net.sourceforge.htmlunit.cyberneko.HTMLEventInfo;
 import net.sourceforge.htmlunit.cyberneko.HTMLScanner;
 import net.sourceforge.htmlunit.cyberneko.HTMLTagBalancingListener;
+import net.sourceforge.htmlunit.xerces.parsers.AbstractSAXParser;
+import net.sourceforge.htmlunit.xerces.xni.Augmentations;
+import net.sourceforge.htmlunit.xerces.xni.QName;
+import net.sourceforge.htmlunit.xerces.xni.XMLAttributes;
+import net.sourceforge.htmlunit.xerces.xni.XNIException;
+import net.sourceforge.htmlunit.xerces.xni.parser.XMLInputSource;
+import net.sourceforge.htmlunit.xerces.xni.parser.XMLParserConfiguration;
 
 /**
  * <span style="color:red">INTERNAL API - SUBJECT TO CHANGE AT ANY TIME - USE AT YOUR OWN RISK.</span><br>

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/parser/HTMLParser5Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/parser/HTMLParser5Test.java
@@ -33,7 +33,7 @@ public class HTMLParser5Test extends WebDriverTestCase {
             "inputs=document.getElementsByTagName('input');for(i=0;i<inputs.length;i++){f=inputs[i].form;log(f?f.name:null)}";
 
     @Test
-    @Alerts("f1§f1") // FIXME: expected: f1§f2
+    @Alerts("f1§f2")
     public void formEnclosure_table() throws Exception {
         final String[] html = {
                 "<html><body>",
@@ -55,7 +55,7 @@ public class HTMLParser5Test extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("f1§f1") // FIXME: expected: f1§f2
+    @Alerts("f1§f2")
     public void formEnclosure_div() throws Exception {
         final String[] html = {
                 "<html><body>",
@@ -141,7 +141,7 @@ public class HTMLParser5Test extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("f1§f1§f1§f1§f1§f1§f1") // FIXME: expected: f1§f1§f1§f1§f1§null
+    @Alerts("f1§f1§f1§f1§f1§f1§null")
     public void formEnclosure_tree1() throws Exception {
         final String[] html = {
                 "<html><body>",
@@ -168,7 +168,7 @@ public class HTMLParser5Test extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("f1§f1§f1§f2§f2§f2§f2§f2") // FIXME: expected: f1§f1§f1§f2§f2§f2§f1§null
+    @Alerts("f1§f1§f1§f2§f2§f2§f1§null")
     public void formEnclosure_tree2() throws Exception {
         final String[] html = {
                 "<html><body>",
@@ -196,7 +196,7 @@ public class HTMLParser5Test extends WebDriverTestCase {
     }
 
     @Test
-    @Alerts("f1§f1") // FIXME: expected: f1§null
+    @Alerts("f1§null")
     public void formEnclosure_tree3() throws Exception {
         final String[] html = {
                 "<html><body>",

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/parser/HTMLParser5Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/parser/HTMLParser5Test.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gargoylesoftware.htmlunit.html.parser;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebDriverTestCase;
+import com.gargoylesoftware.htmlunit.junit.BrowserRunner;
+import com.gargoylesoftware.htmlunit.junit.BrowserRunner.Alerts;
+
+/**
+ * Test class for {@link HTMLParser}.
+ *
+ * @author Atsushi Nakagawa
+ */
+@RunWith(BrowserRunner.class)
+public class HTMLParser5Test extends WebDriverTestCase {
+
+    private static final String LOG_INPUT_FORMS =
+            "inputs=document.getElementsByTagName('input');for(i=0;i<inputs.length;i++){f=inputs[i].form;log(f?f.name:null)}";
+
+    @Test
+    @Alerts("f1§f1") // FIXME: expected: f1§f2
+    public void formEnclosure_table() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<div>",
+                "<form name='f1'>",
+                "  <table>",
+                "    <input>",
+                "</form>",
+                "<form name='f2'>",
+                "  </table>",
+                "</div>",
+                "<input>",
+                "</form>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+    @Test
+    @Alerts("f1§f1") // FIXME: expected: f1§f2
+    public void formEnclosure_div() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<div>",
+                "<form name='f1'>",
+                "  <div>",
+                "    <input>",
+                "</form>",
+                "<form name='f2'>",
+                "  </div>",
+                "</div>",
+                "<input>",
+                "</form>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+    @Test
+    @Alerts("f1§f1")
+    public void formEnclosure_table_nestedForms() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<div>",
+                "<form name='f1'>",
+                "  <table>",
+                "    <input>",
+                "<form name='f2'>",
+                "  </table>",
+                "</div>",
+                "<input>",
+                "</form>",
+                "</form>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+    @Test
+    @Alerts("f1§f1")
+    public void formEnclosure_div_nestedForms() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<div>",
+                "<form name='f1'>",
+                "  <div>",
+                "    <input>",
+                "<form name='f2'>",
+                "  </div>",
+                "</div>",
+                "<input>",
+                "</form>",
+                "</form>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+    @Test
+    @Alerts("f1§f1§null§null")
+    public void formEnclosure_nestedForms() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<form name='f1'>",
+                "<input>",
+                "<form name='f2'>",
+                "<input>",
+                "</form>",
+                "<input>",
+                "</form>",
+                "<input>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+    @Test
+    @Alerts("f1§f1§f1§f1§f1§f1§f1") // FIXME: expected: f1§f1§f1§f1§f1§null
+    public void formEnclosure_tree1() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<div>",
+                "<form name='f1'>",
+                "  <input>",
+                "  <div>",
+                "    <input>",
+                "    <table>",
+                "      <input>",
+                "</form>",
+                "      <input>",
+                "    </table>",
+                "    <input>",
+                "  </div>",
+                "  <input>",
+                "</div>",
+                "<input>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+    @Test
+    @Alerts("f1§f1§f1§f2§f2§f2§f2§f2") // FIXME: expected: f1§f1§f1§f2§f2§f2§f1§null
+    public void formEnclosure_tree2() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<form name='f1'>",
+                "  <input>",
+                "  <div>",
+                "    <input>",
+                "</form>",
+                "    <input>",
+                "<form name='f2'>",
+                "    <input>",
+                "    <div>",
+                "      <input>",
+                "</form>",
+                "      <input>",
+                "    </div>",
+                "    <input>",
+                "  </div>",
+                "  <input>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+    @Test
+    @Alerts("f1§f1") // FIXME: expected: f1§null
+    public void formEnclosure_tree3() throws Exception {
+        final String[] html = {
+                "<html><body>",
+                "<form name='f1'>",
+                "  <div>",
+                "    <input>",
+                "</form>",
+                "  </div>",
+                "  <input>",
+                "<script>" + LOG_TITLE_FUNCTION + LOG_INPUT_FORMS + "</script>",
+                "</body></html>",
+        };
+
+        loadPageVerifyTitle2(String.join("\n", html));
+    }
+
+}


### PR DESCRIPTION
This PR contains:
* Fixes to `HtmlUnitNekoDOMBuilder` for better handling of `<form></form>` to fix issues with `<input>` ownership
    * This fixes https://sourceforge.net/p/htmlunit/bugs/1630/
* Refactoring `HtmlUnitNekoDOMBuilder.addNodeToRightParent()` for readability and extensibility
