### PR TITLE
Fix incorrect handling of url=undefined by History.push/replaceState()

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/History.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/History.java
@@ -45,6 +45,7 @@ import net.sourceforge.htmlunit.corejs.javascript.Context;
  * @author Ahmed Ashour
  * @author Ronald Brill
  * @author Adam Afeltowicz
+ * @author Lai Quang Duong
  */
 @JsxClass
 public class History extends HtmlUnitScriptable {
@@ -127,13 +128,13 @@ public class History extends HtmlUnitScriptable {
      * @param url an optional URL
      */
     @JsxFunction
-    public void replaceState(final Object object, final String title, final String url) {
+    public void replaceState(final Object object, final String title, final Object url) {
         final WebWindow w = getWindow().getWebWindow();
         try {
             URL newStateUrl = null;
-            final HtmlPage page = (HtmlPage) w.getEnclosedPage();
-            if (StringUtils.isNotBlank(url)) {
-                newStateUrl = page.getFullyQualifiedUrl(url);
+            if (url instanceof String && StringUtils.isNotBlank((String) url)) {
+                final HtmlPage page = (HtmlPage) w.getEnclosedPage();
+                newStateUrl = page.getFullyQualifiedUrl((String) url);
             }
             w.getHistory().replaceState(object, newStateUrl);
         }
@@ -149,13 +150,13 @@ public class History extends HtmlUnitScriptable {
      * @param url an optional URL
      */
     @JsxFunction
-    public void pushState(final Object object, final String title, final String url) {
+    public void pushState(final Object object, final String title, final Object url) {
         final WebWindow w = getWindow().getWebWindow();
         try {
             URL newStateUrl = null;
-            final HtmlPage page = (HtmlPage) w.getEnclosedPage();
-            if (StringUtils.isNotBlank(url)) {
-                newStateUrl = page.getFullyQualifiedUrl(url);
+            if (url instanceof String && StringUtils.isNotBlank((String) url)) {
+                final HtmlPage page = (HtmlPage) w.getEnclosedPage();
+                newStateUrl = page.getFullyQualifiedUrl((String) url);
             }
             w.getHistory().pushState(object, newStateUrl);
         }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/History2Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/History2Test.java
@@ -41,6 +41,7 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
  * @author Adam Afeltowicz
  * @author Carsten Steul
  * @author Anton Demydenko
+ * @author Lai Quang Duong
  */
 @RunWith(BrowserRunner.class)
 public class History2Test extends WebDriverTestCase {
@@ -594,6 +595,90 @@ public class History2Test extends WebDriverTestCase {
                 + "   log('onhashchange ' + location.hash);\n"
                 + " }\n"
                 + " window.onhashchange = locationHashChanged;\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§"})
+    public void replaceStateUndefinedObj() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.replaceState(null, '', undefined);\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§undefined"})
+    public void replaceStateUndefinedString() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.replaceState(null, '', 'undefined');\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§"})
+    public void pushStateUndefinedObj() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.pushState(null, '', undefined);\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§undefined"})
+    public void pushStateUndefinedString() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.pushState(null, '', 'undefined');\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
                 + "</script>\n"
                 + "</head>\n"
                 + "<body onload='test()'>\n"


### PR DESCRIPTION
# Overview

This PR fixes the incorrect behaviour of `History.replaceState()` and `History.pushState()` when `undefined` is passed for the `url` parameter.

These two methods treated `undefined` and therefore the url as the string `'undefined'`, and set the `location.href` to a file of that name, when it should instead be ignoring this parameter.

# Tests to reproduce the issue

Below code shows behaviors of HtmlUnit's `history.replaceState()` and expected (e.g. Chrome).

```html
<!DOCTYPE html>
<html>
<head>
<script>

// Assuming location.href is "https://www.example.com/"
history.replaceState(null, '', undefined);

// Expected: "https://www.example.com/"
// HtmlUnit: "https://www.example.com/undefined"
console.log(location.href);

</script>
</head>
<body>
</body>
</html>
```