### PR TITLE
HtmlUnitNekoDOMBuilder: Fix to allow <form> in <table> children

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
@@ -442,7 +442,7 @@ final class HtmlUnitNekoDOMBuilder extends AbstractSAXParser
 
         // Next ensure non-table elements don't appear in tables
         if ("table".equals(currentNodeName) || isTableChild(currentNodeName) || "tr".equals(currentNodeName)) {
-            if ("script".equals(newNodeName)) { // Scripts are exempt
+            if ("script".equals(newNodeName) || "form".equals(newNodeName)) { // Scripts and forms are exempt
                 currentNode.appendChild(newElement);
             }
             else if ("col".equals(newNodeName) && "colgroup".equals(currentNodeName)) { // These are good

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/parser/MalformedHtmlTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/parser/MalformedHtmlTest.java
@@ -777,7 +777,7 @@ public class MalformedHtmlTest extends WebDriverTestCase {
      * @throws Exception if an error occurs
      */
     @Test
-    @Alerts({"2", "1a", "1b", "2", "BODY", "TR", "TABLE", "2"})
+    @Alerts({"2", "1a", "1b", "2", "BODY", "DIV", "TABLE", "2"})
     public void formInTable8() throws Exception {
         final String html = "<html>\n"
                 + "<body>\n"

--- a/src/test/java/com/gargoylesoftware/htmlunit/html/parser/MalformedHtmlTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/html/parser/MalformedHtmlTest.java
@@ -621,7 +621,6 @@ public class MalformedHtmlTest extends WebDriverTestCase {
      */
     @Test
     @Alerts({"3", "1a", "1b", "", "0", "DIV"})
-    @NotYetImplemented
     public void formInTable4() throws Exception {
         final String html = "<html>\n"
                 + "<body>\n"


### PR DESCRIPTION
This PR contains:
* Fix to allow `<form>` in table children just like `<script>`