### PR TITLE
Implement Blob.arrayBuffer()

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/file/Blob.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/file/Blob.java
@@ -54,6 +54,7 @@ import net.sourceforge.htmlunit.corejs.javascript.typedarrays.NativeArrayBufferV
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 @JsxClass
 public class Blob extends HtmlUnitScriptable {
@@ -244,6 +245,23 @@ public class Blob extends HtmlUnitScriptable {
     @JsxGetter
     public String getType() {
         return getBackend().getType(getBrowserVersion());
+    }
+
+    /**
+     * @return a Promise that resolves with an ArrayBuffer containing the
+     * data in binary form.
+     */
+    @JsxFunction({CHROME, EDGE, FF, FF_ESR})
+    public Object arrayBuffer() {
+        byte[] bytes = getBytes();
+        NativeArrayBuffer buffer = new NativeArrayBuffer(bytes.length);
+        System.arraycopy(bytes, 0, buffer.getBuffer(), 0, bytes.length);
+        ScriptRuntime.setObjectProtoAndParent(buffer, getParentScope());
+
+        final Scriptable scope = ScriptableObject.getTopLevelScope(this);
+        final LambdaConstructor ctor = (LambdaConstructor) getProperty(scope, "Promise");
+        final LambdaFunction resolve = (LambdaFunction) getProperty(ctor, "resolve");
+        return resolve.call(Context.getCurrentContext(), this, ctor, new Object[] {buffer});
     }
 
     @JsxFunction

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/file/Blob.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/file/Blob.java
@@ -37,6 +37,7 @@ import com.gargoylesoftware.htmlunit.javascript.configuration.JsxClass;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxConstructor;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxFunction;
 import com.gargoylesoftware.htmlunit.javascript.configuration.JsxGetter;
+import com.gargoylesoftware.htmlunit.javascript.host.ReadableStream;
 
 import net.sourceforge.htmlunit.corejs.javascript.Context;
 import net.sourceforge.htmlunit.corejs.javascript.LambdaConstructor;
@@ -301,6 +302,11 @@ public class Blob extends HtmlUnitScriptable {
 
         blob.setBackend(new InMemoryBackend(getBackend().getBytes(usedStart, usedEnd), null, usedContentType, 0L));
         return blob;
+    }
+
+    @JsxFunction
+    public ReadableStream stream() {
+        throw new UnsupportedOperationException("Blob.stream() is not yet implemented.");
     }
 
     /**

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/file/BlobTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/file/BlobTest.java
@@ -28,6 +28,7 @@ import com.gargoylesoftware.htmlunit.util.MimeType;
  * Tests for {@link com.gargoylesoftware.htmlunit.javascript.host.file.Blob}.
  *
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 @RunWith(BrowserRunner.class)
 public class BlobTest extends WebDriverTestCase {
@@ -376,6 +377,38 @@ public class BlobTest extends WebDriverTestCase {
                 + "      blob.text().then(function(text) { log(text); });\n"
                 + "    } catch(e) { log('TypeError ' + (e instanceof TypeError)); }\n"
                 + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body>\n"
+                + "</html>";
+
+        loadPage2(html);
+        verifyTitle2(DEFAULT_WAIT_TIME, getWebDriver(), getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts(DEFAULT = {"function", "Hello HtmlUnit"},
+            IE = {"undefined", "TypeError true"})
+    public void arrayBuffer() throws Exception {
+        final String html = HtmlPageTest.STANDARDS_MODE_PREFIX_
+                + "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "function test() {\n"
+                + "  var blob = new Blob(['Hello HtmlUnit'], {type : 'text/html'});\n"
+                + "  log(typeof blob.arrayBuffer);\n"
+                + "  try {\n"
+                + "    blob.arrayBuffer().then(function(buf) {\n"
+                + "      var arr = new Uint8Array(buf);\n"
+                + "      log(String.fromCharCode.apply(String, arr));\n"
+                + "    })\n"
+                + "  } catch(e) { log('TypeError ' + (e instanceof TypeError)); }\n"
+                + "}\n"
                 + "</script>\n"
                 + "</head>\n"
                 + "<body onload='test()'>\n"


### PR DESCRIPTION
This PR
* Adds the missing implemetation of `Blob.arrayBuffer()`
* Adds a stub implementation of `Blob.stream()` that just throws `UnsupportedOperationException`