### PR TITLE
Implement URLSearchParams.forEach()

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParams.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParams.java
@@ -52,6 +52,7 @@ import net.sourceforge.htmlunit.corejs.javascript.Undefined;
  * @author Ronald Brill
  * @author Ween Jiann
  * @author cd alexndr
+ * @author Lai Quang Duong
  */
 @JsxClass({CHROME, EDGE, FF, FF_ESR})
 public class URLSearchParams extends HtmlUnitScriptable {
@@ -156,7 +157,6 @@ public class URLSearchParams extends HtmlUnitScriptable {
 
     private List<NameValuePair> splitQuery() {
         String search = url_.getSearch();
-        search = UrlUtils.decode(search);
         return splitQuery(search);
     }
 
@@ -170,7 +170,8 @@ public class URLSearchParams extends HtmlUnitScriptable {
 
         final String[] parts = StringUtils.split(params, '&');
         for (final String part : parts) {
-            splitted.add(splitQueryParameter(part));
+            final NameValuePair pair = splitQueryParameter(part);
+            splitted.add(new NameValuePair(UrlUtils.decode(pair.getName()), UrlUtils.decode(pair.getValue())));
         }
         return splitted;
     }
@@ -205,7 +206,6 @@ public class URLSearchParams extends HtmlUnitScriptable {
             pairs = new ArrayList<>(1);
         }
         else {
-            search = UrlUtils.decode(search);
             pairs = splitQuery(search);
         }
 
@@ -400,9 +400,9 @@ public class URLSearchParams extends HtmlUnitScriptable {
                 newSearch.append('&');
             }
             newSearch
-                .append(nameValuePair.getName())
+                .append(UrlUtils.encodeQueryPart(nameValuePair.getName()))
                 .append('=')
-                .append(nameValuePair.getValue());
+                .append(UrlUtils.encodeQueryPart(nameValuePair.getValue()));
         }
 
         return newSearch.toString();

--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParams.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParams.java
@@ -41,6 +41,8 @@ import com.gargoylesoftware.htmlunit.util.UrlUtils;
 
 import net.sourceforge.htmlunit.corejs.javascript.Context;
 import net.sourceforge.htmlunit.corejs.javascript.ES6Iterator;
+import net.sourceforge.htmlunit.corejs.javascript.Function;
+import net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime;
 import net.sourceforge.htmlunit.corejs.javascript.Scriptable;
 import net.sourceforge.htmlunit.corejs.javascript.ScriptableObject;
 import net.sourceforge.htmlunit.corejs.javascript.Undefined;
@@ -343,6 +345,36 @@ public class URLSearchParams extends HtmlUnitScriptable {
             }
         }
         return false;
+    }
+
+    /**
+     * The URLSearchParams.forEach() method allows iteration through all key/value pairs contained in this object via a callback function.
+     * @param callback Function to execute on each key/value pairs
+     */
+    @JsxFunction
+    public void forEach(final Object callback) {
+        if (!(callback instanceof Function)) {
+            throw ScriptRuntime.typeError("Foreach callback '" + ScriptRuntime.toString(callback) + "' is not a function");
+        }
+
+        final Function fun = (Function)callback;
+
+        String currentSearch = null;
+        List<NameValuePair> params = null;
+        // This must be indexes instead of iterator() for correct behavior when of list changes while iterating
+        for (int i = 0;; i++) {
+            String search = url_.getSearch();
+            if (!search.equals(currentSearch)) {
+                params = splitQuery(search);
+                currentSearch = search;
+            }
+            if (i >= params.size()) {
+                break;
+            }
+            
+            NameValuePair param = params.get(i);
+            fun.call(Context.getCurrentContext(), getParentScope(), this, new Object[] {param.getValue(), param.getName(), this});
+        }
     }
 
     /**

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParamsTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParamsTest.java
@@ -27,6 +27,7 @@ import com.gargoylesoftware.htmlunit.junit.BrowserRunner.HtmlUnitNYI;
  *
  * @author Ronald Brill
  * @author cd alexndr
+ * @author Lai Quang Duong
  */
 @RunWith(BrowserRunner.class)
 public class URLSearchParamsTest extends WebDriverTestCase {
@@ -241,6 +242,39 @@ public class URLSearchParamsTest extends WebDriverTestCase {
      * @throws Exception if an error occurs
      */
     @Test
+    @Alerts(DEFAULT = {"%3Fkey%3D%26=value", "true",
+                       "%3Fkey%3D%26=value&url=http%3A%2F%2Ffoo.com%2F%3Fx%3D1%26y%3D2%26z%3D3", "http://foo.com/?x=1&y=2&z=3"},
+            IE = {})
+    public void appendSpecialChars() throws Exception {
+        final String html =
+            "<html>\n"
+                + "<head>\n"
+                + "  <script>\n"
+                + LOG_TITLE_FUNCTION
+                + "    function test() {\n"
+                + "      if (self.URLSearchParams) {\n"
+                + "        var param = new URLSearchParams();\n"
+                + "        param.append('?key=&', 'value');\n"
+                + "        log(param);\n"
+                + "        log(param.has('?key=&'));\n"
+                + "        param.append('url', 'http://foo.com/?x=1&y=2&z=3');\n"
+                + "        log(param);\n"
+                + "        log(param.get('url'));\n"
+                + "      }\n"
+                + "    }\n"
+                + "  </script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body>\n"
+                + "</html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
     @Alerts(DEFAULT = {"key=value", "key=value&empty-key=undefined",
                        "key=value&empty-key=undefined&key=overwrite",
                        "key=value&empty-key=undefined&key=overwrite&key-null=null",
@@ -359,13 +393,13 @@ public class URLSearchParamsTest extends WebDriverTestCase {
     @Alerts(DEFAULT = {"key+1=val1&key2=val2", "http://test.com/p?key%201=val1&key2=val2",
                        "key2=val2", "http://test.com/p?key2=val2"},
             IE = {})
-    @HtmlUnitNYI(CHROME = {"key 1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
+    @HtmlUnitNYI(CHROME = {"key+1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
                            "key2=val2", "http://test.com/p?key2=val2"},
-                 EDGE = {"key 1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
+                 EDGE = {"key+1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
                          "key2=val2", "http://test.com/p?key2=val2"},
-                 FF = {"key 1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
+                 FF = {"key+1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
                        "key2=val2", "http://test.com/p?key2=val2"},
-                 FF_ESR = {"key 1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
+                 FF_ESR = {"key+1=val1&key2=val2", "http://test.com/p?key 1=val1&key2=val2",
                            "key2=val2", "http://test.com/p?key2=val2"})
     public void deleteFromUrlSpecialChars() throws Exception {
         final String html =

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParamsTest.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/URLSearchParamsTest.java
@@ -724,6 +724,46 @@ public class URLSearchParamsTest extends WebDriverTestCase {
      * @throws Exception if an error occurs
      */
     @Test
+    @Alerts(DEFAULT = {"key1-val1", "key2-val2", "key3-val3",
+                       "key1-val1", "key3-val3",
+                       "key2-val2", "key3-val3"},
+            IE = {})
+    public void forEach() throws Exception {
+        final String html =
+            "<html>\n"
+                + "<head>\n"
+                + "  <script>\n"
+                + LOG_TITLE_FUNCTION
+                + "    function test() {\n"
+                + "      if (self.URLSearchParams) {\n"
+                + "        var param = new URLSearchParams('key1=val1&key2=val2&key3=val3');\n"
+                + "        param.forEach((value, key) => {\n"
+                + "          log(key + '-' + value);\n"
+                + "        });\n"
+                + "        param.forEach((value, key) => {\n"
+                + "          log(key + '-' + value);\n"
+                + "          if (value == 'val1' || value == 'val2') {\n"
+                + "            param.delete(key);\n"
+                + "          }\n"
+                + "        });\n"
+                + "        param.forEach((value, key) => {\n"
+                + "          log(key + '-' + value);\n"
+                + "        });\n"
+                + "      }\n"
+                + "    }\n"
+                + "  </script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body>\n"
+                + "</html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
     @Alerts(DEFAULT = {"function entries() { [native code] }", "[object URLSearchParams Iterator]",
                        "key1-val1", "key2-", "key1-val3", "-val4", "true"},
             IE = {})


### PR DESCRIPTION
This PR:
* Fixes to incorrect splitting by `URLSeachParams` when parameters contain url-encoded required characters like "&"
* Adds an implementation of `URLSeachParams.forEach()`

FWIW, this was the code used to compare htmlunit vs Chrome behaviour of `URLSeachParams`'s splitting.  This PR fixes all the differences and I've rolled the important bits into the `URLSeachParamsTest.appendSpecialChars()` test.

```html
<!DOCTYPE html>
<html>
<head>
<script>
var param = new URLSearchParams();
param.append("?x=1&", "foo");
param.append("bar", "http://foo.com/?x=1&y=2&z=3")
param.append("foobar", "baz")

// chrome: %3Fx%3D1%26=foo&bar=http%3A%2F%2Ffoo.com%2F%3Fx%3D1%26y%3D2%26z%3D3&foobar=baz
// htmlunit: x=1&=foo&bar=http%3A%2F%2Ffoo.com%2F%3Fx%3D1&y=2&z=3&foobar=baz
console.log(param.toString());

// chrome: true
// htmlunit: false
console.log(param.has("?x=1&"));

// chrome: http://foo.com/?x=1&y=2&z=3
// htmlunit: http://foo.com/?x=1
console.log(param.get("bar"));

param.set("foobar", "foo?bar&");

// chrome: foo?bar&
// htmlunit: foo?bar
console.log(param.get("foobar"));

param.delete("?x=1&");

// chrome: bar=http%3A%2F%2Ffoo.com%2F%3Fx%3D1%26y%3D2%26z%3D3&foobar=foo%3Fbar%26
// htmlunit: x=1&=foo&bar=http%3A%2F%2Ffoo.com%2F%3Fx%3D1&y=2&z=3&foobar=foo%3Fbar
console.log(param.toString());
</script>
</head>
<body>
</body>
</html>
```
