### PR TITLE
Fix possible NPE in ElementCssStyleDeclaration.getStylePriority()

### DIFF
--- a/src/main/java/org/htmlunit/css/ElementCssStyleDeclaration.java
+++ b/src/main/java/org/htmlunit/css/ElementCssStyleDeclaration.java
@@ -60,7 +60,7 @@ public class ElementCssStyleDeclaration extends AbstractCssStyleDeclaration {
     @Override
     public String getStylePriority(final String name) {
         final StyleElement element = domElement_.getStyleElement(name);
-        if (element.getValue() != null) {
+        if (element != null && element.getValue() != null) {
             return element.getPriority();
         }
         return "";


### PR DESCRIPTION
This PR fixes an issue where `ElementCssStyleDeclaration.getStylePriority()` can throw `NPE` when the style element is `null`.