### PR TITLE
Regexp "[^]" should match any character, including new line

### DIFF
--- a/src/main/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverter.java
+++ b/src/main/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverter.java
@@ -240,7 +240,7 @@ public class RegExpJsToJavaConverter {
                 else if (']' == next) {
                     // [^]
                     tape_.move(-3);
-                    tape_.replace(3, ".");
+                    tape_.replace(3, "[\\s\\S]");
                 }
                 else {
                     tape_.move(-1);

--- a/src/test/java/org/htmlunit/javascript/regexp/HtmlUnitRegExpProxyTest.java
+++ b/src/test/java/org/htmlunit/javascript/regexp/HtmlUnitRegExpProxyTest.java
@@ -1135,10 +1135,10 @@ public class HtmlUnitRegExpProxyTest extends WebDriverTestCase {
      * @throws Exception if the test fails
      */
     @Test
-    @Alerts("abc")
+    @Alerts("ab\nc")
     public void specialBrackets6() throws Exception {
         // [^] matches any character in JS
-        testEvaluate("'abc'.match(/[^]*/)[0]");
+        testEvaluate("'ab\\nc'.match(/[^]*/)[0]");
     }
 
     /**

--- a/src/test/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverterTest.java
+++ b/src/test/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverterTest.java
@@ -471,8 +471,8 @@ public class RegExpJsToJavaConverterTest {
         assertEquals("(?!)", regExpJsToJavaConverter.convert("[]"));
         assertEquals("x(?!)y", regExpJsToJavaConverter.convert("x[]y"));
 
-        assertEquals(".", regExpJsToJavaConverter.convert("[^]"));
-        assertEquals("x.y", regExpJsToJavaConverter.convert("x[^]y"));
+        assertEquals("[\\s\\S]", regExpJsToJavaConverter.convert("[^]"));
+        assertEquals("x[\\s\\S]y", regExpJsToJavaConverter.convert("x[^]y"));
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue with JS regex handling of `[^]` where it fails to match new line characters.