### PR TITLE
Fix handshake_failure when using SOCKS proxy with SNI-enabled server

### DIFF
--- a/src/main/java/org/htmlunit/httpclient/HtmlUnitSSLConnectionSocketFactory.java
+++ b/src/main/java/org/htmlunit/httpclient/HtmlUnitSSLConnectionSocketFactory.java
@@ -174,8 +174,8 @@ public final class HtmlUnitSSLConnectionSocketFactory extends SSLConnectionSocke
                 throw new ConnectTimeoutException("Connect to " + socksProxyAddress + " timed out");
             }
 
-            final Socket sslSocket = getSSLSocketFactory().createSocket(underlying, socksProxy.getHostName(),
-                    socksProxy.getPort(), true);
+            final Socket sslSocket = getSSLSocketFactory().createSocket(underlying, remoteAddress.getHostName(),
+                    remoteAddress.getPort(), true);
             configureSocket((SSLSocket) sslSocket, context);
             return sslSocket;
         }


### PR DESCRIPTION
Hello!

I was getting the following exception when connecting to a SNI-enabled server via SOCKS proxy:
```
javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
```