### PR TITLE
WIP - Jetty 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <additionalparam>-Xdoclint:none</additionalparam>
 
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <htmlunitcssparser.version>3.6.0</htmlunitcssparser.version>
         <htmlunitneko.version>3.6.0</htmlunitneko.version>
@@ -34,7 +34,7 @@
         <selenium.version>4.14.1</selenium.version>
 
         <httpcomponents.version>4.5.14</httpcomponents.version>
-        <jetty.version>9.4.53.v20231009</jetty.version>
+        <jetty.version>11.0.17</jetty.version>
         <log4j.version>2.21.0</log4j.version>
 
         <!-- As a property, as it is included in Checkstyle build -->
@@ -1209,7 +1209,7 @@
         <!-- Jetty -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-client</artifactId>
+            <artifactId>websocket-jetty-client</artifactId>
             <version>${jetty.version}</version>
         </dependency>
 
@@ -1330,7 +1330,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
+            <artifactId>websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This is a work in progress.  What are the plans with htmlunit in relation to JakartaEE?  To get there, jetty 11 must be used.

The following pom changes are at minimum required.

This produces

```logs
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project htmlunit: Compilation failure: Compilation failure:
[ERROR] .../htmlunit/src/main/java/org/htmlunit/websocket/JettyWebSocketAdapter.java:[46,43] org.eclipse.jetty.util.ssl.SslContextFactory is abstract; cannot be instantiated
[ERROR] .../htmlunit/src/main/java/org/htmlunit/websocket/JettyWebSocketAdapter.java:[56,16] cannot find symbol
[ERROR]   symbol:   method setExecutor(java.util.concurrent.Executor)
[ERROR]   location: variable client_ of type org.eclipse.jetty.websocket.client.WebSocketClient
[ERROR] .../htmlunit/src/main/java/org/htmlunit/websocket/JettyWebSocketAdapter.java:[60,47] cannot find symbol
[ERROR]   symbol:   method getPolicy()
[ERROR]   location: variable client_ of type org.eclipse.jetty.websocket.client.WebSocketClient
[ERROR] .../htmlunit/src/main/java/org/htmlunit/websocket/JettyWebSocketAdapter.java:[67,19] cannot find symbol
[ERROR]   symbol:   method setMaxBinaryMessageBufferSize(int)
[ERROR]   location: variable policy of type org.eclipse.jetty.websocket.api.WebSocketPolicy
[ERROR] .../htmlunit/src/main/java/org/htmlunit/websocket/JettyWebSocketAdapter.java:[75,19] cannot find symbol
[ERROR]   symbol:   method setMaxTextMessageBufferSize(int)
[ERROR]   location: variable policy of type org.eclipse.jetty.websocket.api.WebSocketPolicy
[ERROR] -> [Help 1]
```

This may be a simple fix, didn't look that far as I wanted to understand what plans for JakartaEE are currently.  I suspect it will mean supporting two copies of this framework for a while like most others are doing.

The same effort level appears to be true for javaEE jetty 10 version.  So really moving there would likely support both.