### PR TITLE
Fix for Reflect's properties having an incorrect scope

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/Reflect.java
+++ b/src/main/java/org/htmlunit/javascript/host/Reflect.java
@@ -37,14 +37,12 @@ import org.htmlunit.javascript.configuration.JsxStaticFunction;
 public class Reflect extends HtmlUnitScriptable {
 
     /**
-     * {@inheritDoc}
+     * Creates an instance.
      */
-    @Override
-    public void setParentScope(final Scriptable scope) {
-        super.setParentScope(scope);
+    public Reflect() {
         try {
             final FunctionObject functionObject = new FunctionObject("has",
-                    getClass().getDeclaredMethod("has", Scriptable.class, String.class), scope);
+                    getClass().getDeclaredMethod("has", Scriptable.class, String.class), this);
             defineProperty("has", functionObject, ScriptableObject.DONTENUM);
         }
         catch (final Exception e) {

--- a/src/test/java/org/htmlunit/javascript/host/ReflectTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/ReflectTest.java
@@ -32,7 +32,7 @@ public class ReflectTest extends WebDriverTestCase {
      * @throws Exception if the test fails
      */
     @Test
-    @Alerts(DEFAULT = {"true", "false", "true"},
+    @Alerts(DEFAULT = {"true", "true", "false", "true"},
             IE = "no Reflect")
     public void has() throws Exception {
         final String html = "<html><head>\n"
@@ -40,6 +40,7 @@ public class ReflectTest extends WebDriverTestCase {
             + "<script>\n"
             + LOG_TITLE_FUNCTION
             + "  if (typeof Reflect != 'undefined') {\n"
+            + "    log((Reflect ? Reflect.has : log)({x: 0}, 'x'));\n"
             + "    log(Reflect.has({x: 0}, 'x'));\n"
             + "    log(Reflect.has({x: 0}, 'y'));\n"
             + "    log(Reflect.has({x: 0}, 'toString'));\n"


### PR DESCRIPTION
This PR does the following:
- Fix an issue where properties of Reflect have their scope incorrectly set to the parent scope of Reflect rather than the Reflect instance itself
- The issue can be seen in this test case:
  ```html
  var foo = {
    bar: 0
  };
  (Reflect ? Reflect.has : console.log)(foo, 'bar')
  ```
    - HtmlUnit 3.0.0 will throw `org.htmlunit.ScriptException: TypeError: Method "has" called on incompatible object.` since it's trying to execute `has()` on window object instead of `Reflect`