### PR TITLE
Implement urlSearchParams[Symbol.iterator] and fix implementation of nodeList[Symbol.iterator]

### DIFF
--- a/src/main/java/org/htmlunit/javascript/JavaScriptEngine.java
+++ b/src/main/java/org/htmlunit/javascript/JavaScriptEngine.java
@@ -659,8 +659,8 @@ public class JavaScriptEngine implements AbstractJavaScriptEngine<Script> {
             final ScriptableObject scriptable) {
         configureConstants(config, scriptable);
         configureProperties(config, scriptable);
-        configureSymbols(config, scriptable);
         configureFunctions(config, scriptable);
+        configureSymbols(config, scriptable);
     }
 
     private static void configureFunctions(final ClassConfiguration config, final ScriptableObject scriptable) {
@@ -731,9 +731,14 @@ public class JavaScriptEngine implements AbstractJavaScriptEngine<Script> {
         final Map<Symbol, Method> symbolMap = config.getSymbolMap();
         if (symbolMap != null) {
             for (final Entry<Symbol, Method> symbolInfo : symbolMap.entrySet()) {
-                final Callable symbolFunction = new FunctionObject(
-                                    symbolInfo.getKey().toString(), symbolInfo.getValue(), scriptable);
-                scriptable.defineProperty(symbolInfo.getKey(), symbolFunction, ScriptableObject.DONTENUM);
+                final Symbol symbol = symbolInfo.getKey();
+                final Method method = symbolInfo.getValue();
+                final String methodName = method.getName();
+
+                final Callable symbolFunction = scriptable.has(methodName, scriptable)
+                        ? (Callable)scriptable.get(methodName, scriptable)
+                        : new FunctionObject(symbol.toString(), method, scriptable);
+                scriptable.defineProperty(symbol, symbolFunction, ScriptableObject.DONTENUM);
             }
         }
     }

--- a/src/main/java/org/htmlunit/javascript/host/URLSearchParams.java
+++ b/src/main/java/org/htmlunit/javascript/host/URLSearchParams.java
@@ -43,6 +43,7 @@ import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
 import org.htmlunit.javascript.configuration.JsxFunction;
 import org.htmlunit.javascript.configuration.JsxGetter;
+import org.htmlunit.javascript.configuration.JsxSymbol;
 import org.htmlunit.util.NameValuePair;
 import org.htmlunit.util.UrlUtils;
 
@@ -386,6 +387,7 @@ public class URLSearchParams extends HtmlUnitScriptable {
      * @return an iterator.
      */
     @JsxFunction
+    @JsxSymbol(value = {CHROME, EDGE, FF, FF_ESR}, symbolName = "iterator")
     public Object entries() {
         final List<NameValuePair> splitted = splitQuery();
 

--- a/src/main/java/org/htmlunit/javascript/host/dom/NodeList.java
+++ b/src/main/java/org/htmlunit/javascript/host/dom/NodeList.java
@@ -126,6 +126,7 @@ public class NodeList extends AbstractList implements Callable {
      * @return an {@link NativeArrayIterator}
      */
     @JsxFunction({CHROME, EDGE, FF, FF_ESR})
+    @JsxSymbol(value = {CHROME, EDGE, FF, FF_ESR}, symbolName = "iterator")
     public ES6Iterator values() {
         return new NativeArrayIterator(getParentScope(), this, NativeArrayIterator.ARRAY_ITERATOR_TYPE.VALUES);
     }
@@ -137,11 +138,6 @@ public class NodeList extends AbstractList implements Callable {
     @JsxFunction({CHROME, EDGE, FF, FF_ESR})
     public ES6Iterator entries() {
         return new NativeArrayIterator(getParentScope(), this, NativeArrayIterator.ARRAY_ITERATOR_TYPE.ENTRIES);
-    }
-
-    @JsxSymbol({CHROME, EDGE, FF, FF_ESR})
-    public ES6Iterator iterator() {
-        return values();
     }
 
     /**

--- a/src/test/java/org/htmlunit/javascript/host/URLSearchParamsTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/URLSearchParamsTest.java
@@ -764,7 +764,7 @@ public class URLSearchParamsTest extends WebDriverTestCase {
      * @throws Exception if an error occurs
      */
     @Test
-    @Alerts(DEFAULT = {"function entries() { [native code] }", "[object URLSearchParams Iterator]",
+    @Alerts(DEFAULT = {"true", "function entries() { [native code] }", "[object URLSearchParams Iterator]",
                        "key1-val1", "key2-", "key1-val3", "-val4", "true"},
             IE = {})
     public void entries() throws Exception {
@@ -776,6 +776,10 @@ public class URLSearchParamsTest extends WebDriverTestCase {
             + "    function test() {\n"
             + "      if (self.URLSearchParams) {\n"
             + "        var param = new URLSearchParams('key1=val1&key2=&key1=val3&=val4');\n"
+
+            + "        if (typeof Symbol != 'undefined') {\n"
+            + "          log(param[Symbol.iterator] === param.entries);\n"
+            + "        }\n"
 
             + "        log(param.entries);\n"
             + "        var iter = param.entries();\n"

--- a/src/test/java/org/htmlunit/javascript/host/dom/NodeListTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/dom/NodeListTest.java
@@ -214,7 +214,7 @@ public class NodeListTest extends WebDriverTestCase {
      * @throws Exception on test failure
      */
     @Test
-    @Alerts(DEFAULT = {"[object HTMLHtmlElement]", "[object HTMLHeadElement]",
+    @Alerts(DEFAULT = {"true", "[object HTMLHtmlElement]", "[object HTMLHeadElement]",
                        "[object HTMLScriptElement]", "[object HTMLBodyElement]",
                        "[object HTMLDivElement]"},
             IE = "no for..of")
@@ -224,6 +224,11 @@ public class NodeListTest extends WebDriverTestCase {
                 + LOG_TITLE_FUNCTION
                 + "  function test() {\n"
                 + "    var nodeList = document.querySelectorAll('*');\n"
+
+                + "    if (typeof Symbol != 'undefined') {\n"
+                + "      log(nodeList[Symbol.iterator] === nodeList.values);\n"
+                + "    }\n"
+
                 + "    if (!nodeList.forEach) {\n"
                 + "      log('no for..of');\n"
                 + "      return;\n"


### PR DESCRIPTION
This PR does the following:

* Fix an issue where `nodeList[Symbol.iterator] === nodeList.values` is `false` even though it should be `true`
    
    * To do this:
        *  We fix `JavaScriptEngine` so that putting both the `@JsxSymbol` and `@JsxFunction` annotations on the same method _works properly_
            * i.e. Create a single `FunctionObject` instance that maps to both the function and the `Symbol.iterator` properties, rather than creating separate `FunctionObject` instances for the two properties.
        * The method `NodeList.iterator()` is removed and `@JsxSymbol` is moved to `NodeList.values()`
* Fix an issue where `Object.fromEntries(new URLSearchParams())` throws `TypeError: Cannot find function Symbol(Symbol.iterator)`

    * This is fixed by implementing the `Symbol.iterator` property on `URLSearchParams`
