### PR TITLE
URLSearchParams: Add missing implementation for constructor

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/xml/FormData.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/FormData.java
@@ -37,6 +37,7 @@ import org.htmlunit.javascript.HtmlUnitScriptable;
 import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
 import org.htmlunit.javascript.configuration.JsxFunction;
+import org.htmlunit.javascript.configuration.JsxSymbol;
 import org.htmlunit.javascript.host.file.File;
 import org.htmlunit.javascript.host.html.HTMLFormElement;
 import org.htmlunit.util.KeyDataPair;
@@ -282,6 +283,7 @@ public class FormData extends HtmlUnitScriptable {
      * @return An Iterator that contains all the requestParameters name[0] and value[1]
      */
     @JsxFunction({CHROME, EDGE, FF, FF_ESR})
+    @JsxSymbol(value = {CHROME, EDGE, FF, FF_ESR}, symbolName = "iterator")
     public Scriptable entries() {
         return new FormDataIterator(this, "FormData Iterator", requestParameters_);
     }

--- a/src/test/java/org/htmlunit/javascript/host/URLSearchParamsTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/URLSearchParamsTest.java
@@ -58,6 +58,182 @@ public class URLSearchParamsTest extends WebDriverTestCase {
         loadPageVerifyTitle2(html);
     }
 
+    @Test
+    @Alerts(DEFAULT = {"", "Failed to construct 'URLSearchParams': The provided value cannot be converted to a sequence.",
+            "foo=1&bar=2&null=null", "Failed to construct 'URLSearchParams': Sequence initializer must only contain pair elements.",
+            "a%2Cb=1%2C2%2C3", "Failed to construct 'URLSearchParams': The object must have a callable @@iterator property."},
+            IE = {})
+    public void ctorArray() throws Exception {
+        final String html =
+            "<html>\n"
+            + "<head>\n"
+            + "  <script>\n"
+            + LOG_TITLE_FUNCTION
+            + "    function test() {\n"
+            + "      if (self.URLSearchParams) {\n"
+            + "        log(new URLSearchParams(Array(0)));\n"
+            + "        try {\n"
+            + "          new URLSearchParams(Array(1));\n"
+            + "        } catch (ex) {\n"
+            + "          log(ex.message);\n"
+            + "        }\n"
+            + "\n"
+            + "        log(new URLSearchParams([\n"
+            + "          ['foo', '1'],\n"
+            + "          ['bar', '2'],\n"
+            + "          [null, null],\n"
+            + "        ]));\n"
+            + "\n"
+            + "        try {\n"
+            + "          new URLSearchParams([\n"
+            + "            ['foo', '1', '2'],\n"
+            + "          ]);\n"
+            + "        } catch (ex) {\n"
+            + "          log(ex.message);\n"
+            + "        }\n"
+            + "\n"
+            + "        log(new URLSearchParams([\n"
+            + "          [\n"
+            + "            ['a', 'b'],\n"
+            + "            ['1', '2', '3']\n"
+            + "          ],\n"
+            + "        ]));\n"
+            + "\n"
+            + "        try {\n"
+            + "          new URLSearchParams([\n"
+            + "            {'foo': 1},\n"
+            + "            {'bar': 2},\n"
+            + "          ]);\n"
+            + "        } catch (ex) {\n"
+            + "          log(ex.message);\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  </script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "</body>\n"
+            + "</html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts(DEFAULT = {"foo=1&bar=2", "foo=%5Bobject+Object%5D&bar=3"},
+            IE = {})
+    public void ctorObject() throws Exception {
+        final String html =
+            "<html>\n"
+            + "<head>\n"
+            + "  <script>\n"
+            + LOG_TITLE_FUNCTION
+            + "    function test() {\n"
+            + "      if (self.URLSearchParams) {\n"
+            + "        log(new URLSearchParams({\n"
+            + "          foo: '1',\n"
+            + "          bar: '2'\n"
+            + "        }));\n"
+            + "\n"
+            + "        log(new URLSearchParams({\n"
+            + "          'foo': {\n"
+            + "            'x': '1',\n"
+            + "            'y': '2'\n"
+            + "          },\n"
+            + "          'bar': '3',\n"
+            + "        }))\n;"
+            + "      }\n"
+            + "    }\n"
+            + "  </script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "</body>\n"
+            + "</html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts(DEFAULT = {"foo=1&bar=%5Bobject+Object%5D&foobar=4%2C5%2C6", "foo=1&bar=2", "foo=1&bar=2",
+            "Failed to construct 'URLSearchParams': Iterator object must be an object.",
+            "Failed to construct 'URLSearchParams': @@iterator must be a callable",
+            "Failed to construct 'URLSearchParams': Expected next() function on iterator.", "foo=1&bar=2",
+            "Failed to construct 'URLSearchParams': The provided value cannot be converted to a sequence."},
+            IE = {})
+    public void ctorIterable() throws Exception {
+        final String html =
+            "<html>\n"
+            + "<head>\n"
+            + "  <script>\n"
+            + LOG_TITLE_FUNCTION
+            + "    function test() {\n"
+            + "      if (self.URLSearchParams) {\n"
+            + "        var map = new Map();\n"
+            + "        map.set('foo', 1);\n"
+            + "        map.set('bar', {\n"
+            + "          'x': 1,\n"
+            + "          'y': 2,\n"
+            + "        });\n"
+            + "        map.set('foobar', [4, 5, 6]);\n"
+            + "        log(new URLSearchParams(map));\n"
+            + "\n"
+            + "        var formData = new FormData();\n"
+            + "        formData.append('foo', '1');\n"
+            + "        formData.append('bar', '2');\n"
+            + "        log(new URLSearchParams(formData));\n"
+            + "\n"
+            + "        var searchParams = new URLSearchParams('foo=1&bar=2');\n"
+            + "        log(new URLSearchParams(searchParams));\n"
+            + "\n"
+            + "        try {\n"
+            + "          var brokenIterable = {};\n"
+            + "          brokenIterable[Symbol.iterator] = function (){};\n"
+            + "          new URLSearchParams(brokenIterable);\n"
+            + "        } catch (ex) {\n"
+            + "          log(ex.message);\n"
+            + "        }\n"
+            + "\n"
+            + "        try {\n"
+            + "          var brokenIterable = {};\n"
+            + "          brokenIterable[Symbol.iterator] = 1;\n"
+            + "          new URLSearchParams(brokenIterable);\n"
+            + "        } catch (ex) {\n"
+            + "          log(ex.message);\n"
+            + "        }\n"
+            + "\n"
+            + "        try {\n"
+            + "          var brokenIterable = {};\n"
+            + "          brokenIterable[Symbol.iterator] = function (){ return {} };\n"
+            + "          new URLSearchParams(brokenIterable);\n"
+            + "        } catch (ex) {\n"
+            + "          log(ex.message);\n"
+            + "        }\n"
+            + "\n"
+            + "        var generatorObject = (function* () {\n"
+            + "          yield ['foo', 1];\n"
+            + "          yield ['bar', 2];\n"
+            + "        })();\n"
+            + "        log(new URLSearchParams(generatorObject));\n"
+            + "\n"
+            + "        try {\n"
+            + "          var generatorObject = (function* () {\n"
+            + "            yield 1;\n"
+            + "            yield 2;\n"
+            + "          })();\n"
+            + "          new URLSearchParams(generatorObject);\n"
+            + "        } catch (ex) {\n"
+            + "          log(ex.message);\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  </script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "</body>\n"
+            + "</html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
     /**
      * @throws Exception if an error occurs
      */


### PR DESCRIPTION
# Overview

This PR does the following:
- Adds the missing `[Symbol.iterator]` for `FormData.entries()`
- Adds the missing implementation to the constructor of `URLSearchParams` for sequence and record arguments

# Notes

* We implemented `IterationProtocolIterator` because we couldn't find existing utility for iterating [the iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).

# Details

Below showcases some of the missing behaviours (tested on Chrome) implemented by this PR:

* Name-values object

  ```js
  // foo=1&bar=2
  console.log(new URLSearchParams({
    foo: "1",
    bar: "2",
  }).toString());
  ```

* Name-values defined through sequence

  ```js
  // foo=1&bar=2
  console.log(new URLSearchParams([
    ["foo", "1"],
    ["bar", 2],
  ]).toString());
  ```

* Non-string name and value

  ```js
  // x%2Cy%2C%5Bobject+Object%5D=1%2C%5Bobject+Object%5D%2Cc
  console.log(new URLSearchParams([
    [
      ["x", "y", {"z": 3}],
      [1, {"a": 2}, "c"]
    ],
  ]).toString()); 
  ```

* Missing name-value pair

  ```js
  // Chrome: Failed to construct 'URLSearchParams': The provided value cannot be converted to a sequence.
  new URLSearchParams(Array(1));
  ```

* Non sequence name-value

  ```js
  // Chrome: "Failed to construct 'URLSearchParams': The object must have a callable @@iterator property."
  new URLSearchParams([
    {},
  ]);
  ```

* Extra element after name and value
  ```js
  // Chrome: "Failed to construct 'URLSearchParams': Sequence initializer must only contain pair elements"
  new URLSearchParams([
    ["foo", 1, 2],
   ];
  ```


* Bad iterator for `[Symbol.iterator]`

  ```js
  // Chrome: "Failed to construct 'URLSearchParams': Iterator object must be an object."
  new URLSearchParams({[Symbol.iterator]: function (){ }});
  ```

* Bad `next()` for iterator

  ```js
  // Chrome: "Failed to construct 'URLSearchParams': Expected next() function on iterator."
  new URLSearchParams({[Symbol.iterator]: function (){ return {} }});
  ```

* Iterable `FormData`

  ```js
  let f = new FormData();
  f.append("foo", "1");
  f.append("bar", "2");
  // foo=1&bar=2
  console.log(new URLSearchParams(f).toString()); 
  ```

* Iterable `URLSearchParams`

  ```js
  // foo=1&bar=2
  console.log(new URLSearchParams(new URLSearchParams("foo=1&bar=2")).toString()); 
  ```

* Iterable generator

  ```js
  // foo=1&bar=2
  console.log(new URLSearchParams((function* () {
    yield ["foo", 1];
    yield ["bar", 2];
  })()).toString()); 
  ```
