### PR TITLE
Upgrade `log4j-core` to version 2.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <httpcomponents.version>4.5.14</httpcomponents.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
-        <log4j.version>2.20.0</log4j.version>
+        <log4j.version>2.21.0</log4j.version>
 
         <!-- As a property, as it is included in Checkstyle build -->
         <checkstyle.version>9.3</checkstyle.version>
@@ -153,6 +153,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/resources/commons-logging.properties
+++ b/src/test/resources/commons-logging.properties
@@ -1,1 +1,4 @@
 # This is just to override 'commons-logging.properties' in 'httpclient-4.2-test.jar' which disables all logging.
+
+# Workaround for issue apache/logging-log4j2#1865
+org.apache.commons.logging.LogFactory = org.apache.logging.log4j.jcl.LogFactoryImpl


### PR DESCRIPTION
Due to apache/logging-log4j2#1865, upgrading to version `2.21.0` requires a workaround for a `log4j-jcl` bug.