### PR TITLE
Updated CSS3Parser pool implementation

### DIFF
--- a/src/main/java/org/htmlunit/css/CssStyleSheet.java
+++ b/src/main/java/org/htmlunit/css/CssStyleSheet.java
@@ -1012,9 +1012,11 @@ public class CssStyleSheet implements Serializable {
      */
     private static CSSStyleSheetImpl parseCSS(final InputSource source, final WebClient client) {
         CSSStyleSheetImpl ss;
-        try (PooledCSS3Parser pooledParser = client.getCSS3ParserFromPool()) {
+
+        // use a pooled parser, if any available to avoid expensive recreation
+        try (final PooledCSS3Parser pooledParser = client.getCSS3Parser()) {
             final CSSErrorHandler errorHandler = client.getCssErrorHandler();
-            final CSSOMParser parser = new CSSOMParser(pooledParser.css3Parser());
+            final CSSOMParser parser = new CSSOMParser(pooledParser);
             parser.setErrorHandler(errorHandler);
             ss = parser.parseStyleSheet(source, null);
         }
@@ -1041,8 +1043,9 @@ public class CssStyleSheet implements Serializable {
             return media;
         }
 
-        try (PooledCSS3Parser pooledParser = webClient.getCSS3ParserFromPool()) {
-            final CSSOMParser parser = new CSSOMParser(pooledParser.css3Parser());
+        // get us a pooled parser for efficiency because a new parser is expensive
+        try (final PooledCSS3Parser pooledParser = webClient.getCSS3Parser()) {
+            final CSSOMParser parser = new CSSOMParser(pooledParser);
             parser.setErrorHandler(webClient.getCssErrorHandler());
 
             media = new MediaListImpl(parser.parseMedia(mediaString));

--- a/src/main/java/org/htmlunit/html/DomNode.java
+++ b/src/main/java/org/htmlunit/html/DomNode.java
@@ -1864,8 +1864,10 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     protected SelectorList getSelectorList(final String selectors, final WebClient webClient)
             throws IOException {
-        try (PooledCSS3Parser pooledParser = webClient.getCSS3ParserFromPool()) {
-            final CSSOMParser parser = new CSSOMParser(pooledParser.css3Parser());
+
+    	// get us a CSS3Parser from the pool so the chance of reusing it are high
+        try (final PooledCSS3Parser pooledParser = webClient.getCSS3Parser()) {
+            final CSSOMParser parser = new CSSOMParser(pooledParser);
             final CheckErrorHandler errorHandler = new CheckErrorHandler();
             parser.setErrorHandler(errorHandler);
 

--- a/src/test/java/org/htmlunit/WebClient9Test.java
+++ b/src/test/java/org/htmlunit/WebClient9Test.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit;
+
+import org.htmlunit.WebClient.PooledCSS3Parser;
+import org.htmlunit.cssparser.parser.javacc.CSS3Parser;
+import org.htmlunit.junit.BrowserRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for {@link WebClient} and its CSS3Parser pool
+ *
+ * @author René Schwietzke
+ */
+@RunWith(BrowserRunner.class)
+public class WebClient9Test extends SimpleWebTestCase {
+
+    /**
+     * Ensure that we always get fresh parser when there
+     * is none and we already fetched one.
+     */
+    @Test
+    public void newParsersWhenNotReturning() {
+        try (WebClient webClient = new WebClient()) {
+            // ask for a parser
+        	CSS3Parser p1 = webClient.getCSS3Parser();
+
+        	// if we ask again, it is not the same
+        	CSS3Parser p2 = webClient.getCSS3Parser();
+
+        	assertFalse(p1 == p2);
+        }
+    }
+
+    /**
+     * When we close a parser, we get it again when
+     * asking the next time
+     */
+    @SuppressWarnings("resource")
+	@Test
+    public void closedParserIsPooled() {
+        try (WebClient webClient = new WebClient()) {
+            // ask for a parser
+        	PooledCSS3Parser p1;
+        	PooledCSS3Parser p2;
+
+        	try (PooledCSS3Parser p = webClient.getCSS3Parser()) {
+        		assertNotNull(p);
+        		p1 = p;
+        	}
+        	try (PooledCSS3Parser p = webClient.getCSS3Parser()) {
+        		assertNotNull(p);
+        		p2 = p;
+        		assertTrue(p == p1);
+        	}
+        	try (PooledCSS3Parser p = webClient.getCSS3Parser()) {
+        		assertNotNull(p);
+        		assertTrue(p == p2);
+        		assertTrue(p1 == p2);
+        	}
+        }
+    }
+
+    /**
+     * We can nest and get properly different parsers
+     */
+	@SuppressWarnings("resource")
+	@Test
+    public void nestingWorks() {
+        try (WebClient webClient = new WebClient()) {
+        	PooledCSS3Parser p1;
+        	PooledCSS3Parser p2;
+
+        	try (PooledCSS3Parser p11 = webClient.getCSS3Parser()) {
+        		try (PooledCSS3Parser p21 = webClient.getCSS3Parser()) {
+            		assertNotNull(p11);
+            		assertNotNull(p21);
+            		assertFalse(p11 == p21);
+
+            		// keep them
+            		p1 = p11;
+            		p2 = p21;
+        		}
+        	}
+
+        	try (PooledCSS3Parser p11 = webClient.getCSS3Parser()) {
+        		try (PooledCSS3Parser p21 = webClient.getCSS3Parser()) {
+            		assertNotNull(p11);
+            		assertNotNull(p21);
+            		assertFalse(p11 == p21);
+
+            		assertTrue(p11 == p1);
+            		assertTrue(p21 == p2);
+        		}
+        	}
+        }
+    }
+
+    /**
+     * Take one, returned it, need two... get another new one
+     */
+	@SuppressWarnings("resource")
+	@Test
+    public void flow1_2() {
+        try (WebClient webClient = new WebClient()) {
+        	PooledCSS3Parser p1;
+
+        	try (PooledCSS3Parser p11 = webClient.getCSS3Parser()) {
+            	p1 = p11;
+        	}
+
+        	try (PooledCSS3Parser p11 = webClient.getCSS3Parser()) {
+        		assertNotNull(p11);
+        		assertTrue(p11 == p1);
+
+        		try (PooledCSS3Parser p21 = webClient.getCSS3Parser()) {
+            		assertNotNull(p21);
+            		assertFalse(p21 == p11);
+        		}
+        	}
+        }
+    }
+}


### PR DESCRIPTION
Updated pool with a different concept to allow more pooling, lighter synchronization, and avoid leaks when not auto-closed. It also uses AutoCloseable instead of Closeable (this is for IO, not for try-with-resource in general).

I could only run my test cases, the rest comes up with many errors related to JS, so I hope that is not this updated.