### PR TITLE
Htmlunit tuning

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,5 @@
+= Ideas for Performance Changes
+
+* DomNode: Use Copy on Write for listeners to safe on object holders, but CopyOnWriteArrayList is not good enough
+* DomNode: Remove synchronized and find something better without extra cost for more objects, maybe a ReentrantLock at the SGMLPage
+

--- a/src/main/java/org/htmlunit/DefaultPageCreator.java
+++ b/src/main/java/org/htmlunit/DefaultPageCreator.java
@@ -120,12 +120,11 @@ public class DefaultPageCreator implements PageCreator, Serializable {
         }
 
         final String contentTypeLC = org.htmlunit.util.StringUtils
-                                            .toRootLowerCaseWithCache(contentType);
+                                            .toRootLowerCase(contentType);
 
         if (MimeType.isJavascriptMimeType(contentTypeLC)) {
             return PageType.JAVASCRIPT;
         }
-
         switch (contentTypeLC) {
             case MimeType.TEXT_HTML:
             case "image/svg+xml":

--- a/src/main/java/org/htmlunit/css/ComputedCssStyleDeclaration.java
+++ b/src/main/java/org/htmlunit/css/ComputedCssStyleDeclaration.java
@@ -314,7 +314,7 @@ public class ComputedCssStyleDeclaration extends AbstractCssStyleDeclaration {
             final String value = element.getValue();
             if (!"content".equals(name)
                     && !value.contains("url")) {
-                return org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(value);
+                return org.htmlunit.util.StringUtils.toRootLowerCase(value);
             }
             return value;
         }

--- a/src/main/java/org/htmlunit/css/CssStyleSheet.java
+++ b/src/main/java/org/htmlunit/css/CssStyleSheet.java
@@ -625,8 +625,8 @@ public class CssStyleSheet implements Serializable {
                 final String a = element.getAttribute(beginHyphenAttributeCondition.getLocalName());
                 if (beginHyphenAttributeCondition.isCaseInSensitive()) {
                     return selectsHyphenSeparated(
-                            org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(v),
-                            org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(a));
+                            org.htmlunit.util.StringUtils.toRootLowerCase(v),
+                            org.htmlunit.util.StringUtils.toRootLowerCase(a));
                 }
                 return selectsHyphenSeparated(v, a);
 
@@ -636,8 +636,8 @@ public class CssStyleSheet implements Serializable {
                 final String a2 = element.getAttribute(oneOfAttributeCondition.getLocalName());
                 if (oneOfAttributeCondition.isCaseInSensitive()) {
                     return selectsOneOf(
-                            org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(v2),
-                            org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(a2));
+                            org.htmlunit.util.StringUtils.toRootLowerCase(v2),
+                            org.htmlunit.util.StringUtils.toRootLowerCase(a2));
                 }
                 return selectsOneOf(v2, a2);
 

--- a/src/main/java/org/htmlunit/css/ElementCssStyleDeclaration.java
+++ b/src/main/java/org/htmlunit/css/ElementCssStyleDeclaration.java
@@ -86,7 +86,7 @@ public class ElementCssStyleDeclaration extends AbstractCssStyleDeclaration {
         if (element != null && element.getValue() != null) {
             final String value = element.getValue();
             if (!value.contains("url")) {
-                return StringUtils.toRootLowerCaseWithCache(value);
+                return StringUtils.toRootLowerCase(value);
             }
             return value;
         }

--- a/src/main/java/org/htmlunit/html/BaseFrameElement.java
+++ b/src/main/java/org/htmlunit/html/BaseFrameElement.java
@@ -380,7 +380,7 @@ public abstract class BaseFrameElement extends HtmlElement {
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObserver) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
         if (null != attributeValue && SRC_ATTRIBUTE.equals(qualifiedNameLC)) {
             attributeValue = attributeValue.trim();
         }

--- a/src/main/java/org/htmlunit/html/DefaultElementFactory.java
+++ b/src/main/java/org/htmlunit/html/DefaultElementFactory.java
@@ -18,7 +18,6 @@ import static org.htmlunit.BrowserVersionFeatures.KEYGEN_AS_BLOCK;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -28,6 +27,7 @@ import org.apache.commons.logging.LogFactory;
 import org.htmlunit.BrowserVersion;
 import org.htmlunit.SgmlPage;
 import org.htmlunit.javascript.configuration.JavaScriptConfiguration;
+import org.htmlunit.util.OrderedFastHashMap;
 import org.xml.sax.Attributes;
 
 /**
@@ -779,23 +779,25 @@ public class DefaultElementFactory implements ElementFactory {
      * @return the map of attribute values for {@link HtmlElement}s
      */
     static Map<String, DomAttr> toMap(final SgmlPage page, final Attributes attributes) {
-        if (attributes == null) {
-            return null;
-        }
+        final int length = attributes == null ? 0 : attributes.getLength();
+        final Map<String, DomAttr> attributeMap = new OrderedFastHashMap<>(length);
 
-        final Map<String, DomAttr> attributeMap = new LinkedHashMap<>(attributes.getLength());
-        for (int i = 0; i < attributes.getLength(); i++) {
+        for (int i = 0; i < length; i++) {
             final String qName = attributes.getQName(i);
+
             // browsers consider only first attribute (ex: <div id='foo' id='something'>...</div>)
             if (!attributeMap.containsKey(qName)) {
                 String namespaceURI = attributes.getURI(i);
+
                 if (namespaceURI != null && namespaceURI.isEmpty()) {
                     namespaceURI = null;
                 }
+
                 final DomAttr newAttr = new DomAttr(page, namespaceURI, qName, attributes.getValue(i), true);
                 attributeMap.put(qName, newAttr);
             }
         }
+
         return attributeMap;
     }
 

--- a/src/main/java/org/htmlunit/html/DomElement.java
+++ b/src/main/java/org/htmlunit/html/DomElement.java
@@ -52,6 +52,7 @@ import org.htmlunit.cssparser.parser.CSSException;
 import org.htmlunit.cssparser.parser.selector.Selector;
 import org.htmlunit.cssparser.parser.selector.SelectorList;
 import org.htmlunit.cssparser.parser.selector.SelectorSpecificity;
+import org.htmlunit.cyberneko.util.FastHashMap;
 import org.htmlunit.javascript.AbstractJavaScriptEngine;
 import org.htmlunit.javascript.HtmlUnitContextFactory;
 import org.htmlunit.javascript.JavaScriptEngine;
@@ -104,7 +105,7 @@ public class DomElement extends DomNamespaceNode implements Element {
     private NamedAttrNodeMapImpl attributes_;
 
     /** The map holding the namespaces, keyed by URI. */
-    private final Map<String, String> namespaces_ = new HashMap<>();
+    private FastHashMap<String, String> namespaces_;
 
     /** Cache for the styles. */
     private String styleString_;
@@ -135,6 +136,9 @@ public class DomElement extends DomNamespaceNode implements Element {
                 final String attrNamespaceURI = entry.getNamespaceURI();
                 final String prefix = entry.getPrefix();
                 if (attrNamespaceURI != null && prefix != null) {
+                    if (namespaces_ == null) {
+                    	namespaces_ = new FastHashMap<>(1, 0.5f);
+                    }
                     namespaces_.put(attrNamespaceURI, prefix);
                 }
             }
@@ -384,7 +388,7 @@ public class DomElement extends DomNamespaceNode implements Element {
             qualifiedName = localName;
         }
         else {
-            final String prefix = namespaces_.get(namespaceURI);
+            final String prefix = namespaces_ == null ? null : namespaces_.get(namespaceURI);
             if (prefix == null) {
                 qualifiedName = null;
             }
@@ -532,6 +536,9 @@ public class DomElement extends DomNamespaceNode implements Element {
         attributes_.put(qualifiedName, newAttr);
 
         if (namespaceURI != null) {
+        	if (namespaces_ == null) {
+        		namespaces_ = new FastHashMap<>(1, 0.5f);
+        	}
             namespaces_.put(namespaceURI, newAttr.getPrefix());
         }
     }

--- a/src/main/java/org/htmlunit/html/DomElement.java
+++ b/src/main/java/org/htmlunit/html/DomElement.java
@@ -1710,7 +1710,7 @@ class NamedAttrNodeMapImpl implements Map<String, DomAttr>, NamedNodeMap, Serial
         if (caseSensitive_) {
             return name;
         }
-        return StringUtils.toRootLowerCaseWithCache(name);
+        return StringUtils.toRootLowerCase(name);
     }
 
     /**

--- a/src/main/java/org/htmlunit/html/DomNamespaceNode.java
+++ b/src/main/java/org/htmlunit/html/DomNamespaceNode.java
@@ -14,12 +14,11 @@
  */
 package org.htmlunit.html;
 
-import java.util.Locale;
-
 import org.htmlunit.SgmlPage;
 import org.htmlunit.WebAssert;
 import org.htmlunit.html.xpath.XPathHelper;
 import org.htmlunit.javascript.host.dom.Document;
+import org.htmlunit.util.StringUtils;
 
 /**
  * Intermediate base class for DOM Nodes that have namespaces. That includes HtmlElement and HtmlAttr.
@@ -61,7 +60,7 @@ public abstract class DomNamespaceNode extends DomNode {
             prefix_ = qualifiedName_.substring(0, colonPosition);
         }
 
-        localNameLC_ = localName_.toLowerCase(Locale.ROOT);
+        localNameLC_ = StringUtils.toRootLowerCase(localName_);
     }
 
     /**

--- a/src/main/java/org/htmlunit/html/DomNode.java
+++ b/src/main/java/org/htmlunit/html/DomNode.java
@@ -24,12 +24,13 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.htmlunit.BrowserVersionFeatures;
 import org.htmlunit.IncorrectnessListener;
@@ -49,7 +50,6 @@ import org.htmlunit.cssparser.parser.CSSOMParser;
 import org.htmlunit.cssparser.parser.CSSParseException;
 import org.htmlunit.cssparser.parser.selector.Selector;
 import org.htmlunit.cssparser.parser.selector.SelectorList;
-import org.htmlunit.cyberneko.util.FastHashMap;
 import org.htmlunit.html.HtmlElement.DisplayStyle;
 import org.htmlunit.html.serializer.HtmlSerializerNormalizedText;
 import org.htmlunit.html.serializer.HtmlSerializerVisibleText;
@@ -58,6 +58,7 @@ import org.htmlunit.javascript.HtmlUnitScriptable;
 import org.htmlunit.javascript.JavaScriptEngine;
 import org.htmlunit.javascript.host.event.Event;
 import org.htmlunit.javascript.host.html.HTMLDocument;
+import org.htmlunit.util.SerializableLock;
 import org.htmlunit.util.StringUtils;
 import org.htmlunit.xml.XmlPage;
 import org.htmlunit.xpath.xml.utils.PrefixResolver;
@@ -111,11 +112,11 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
     /** The name of the "element" property. Used when watching property change events. */
     public static final String PROPERTY_ELEMENT = "element";
 
+    /** The owning page of this node. */
+    private SgmlPage page_;
+
     /** The parent node. */
     private DomNode parent_;
-
-    /** Start of the child list. */
-    private DomNode firstChild_;
 
     /**
      * The previous sibling. The first child's <code>previousSibling</code> points
@@ -128,13 +129,17 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     private DomNode nextSibling_;
 
-    /** The owning page of this node. */
-    private SgmlPage page_;
+    /** Start of the child list. */
+    private DomNode firstChild_;
+
+    /**
+     * This is the JavaScript object corresponding to this DOM node. It may
+     * be null if there isn't a corresponding JavaScript object.
+     */
+    private HtmlUnitScriptable scriptObject_;
 
     /** The ready state is an IE-only value that is available to a large number of elements. */
     private String readyState_;
-
-    private boolean attachedToPage_;
 
     /**
      * The line number in the source page where the DOM node starts.
@@ -156,23 +161,17 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     private int endColumnNumber_ = -1;
 
-    /**
-     * This is the JavaScript object corresponding to this DOM node. It may
-     * be null if there isn't a corresponding JavaScript object.
-     */
-    private HtmlUnitScriptable scriptObject_;
+    private boolean attachedToPage_;
 
-    /*
-     * The listeners which are to be notified of characterData change. Because
-     * we want to create them ondemand, we must get them via a method calls.
-     */
-    // the CopyOnWriteArrayList allows to iterate and add without disturbing
-    // the iteration at the same time. Only if both occur at the same time
-    // we will create a second data structure, otherwise we are cheap.
-    private volatile CopyOnWriteArrayList<CharacterDataChangeListener> characterDataListeners_;
-    private volatile CopyOnWriteArrayList<DomChangeListener> domListeners_;
+    private final Object listeners_lock_ = new SerializableLock();
 
-    private FastHashMap<String, Object> userData_;
+    /** The listeners which are to be notified of characterData change. */
+    private Collection<CharacterDataChangeListener> characterDataListeners_;
+    private List<CharacterDataChangeListener> characterDataListenersList_;
+
+    private Collection<DomChangeListener> domListeners_;
+    private List<DomChangeListener> domListenersList_;
+    private Map<String, Object> userData_;
 
     /**
      * Creates a new instance.
@@ -645,10 +644,11 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     @Override
     public Object getUserData(final String key) {
+        Object value = null;
         if (userData_ != null) {
-            return userData_.get(key);
+            value = userData_.get(key);
         }
-        return null;
+        return value;
     }
 
     /**
@@ -657,7 +657,7 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
     @Override
     public Object setUserData(final String key, final Object data, final UserDataHandler handler) {
         if (userData_ == null) {
-            userData_ = new FastHashMap<>();
+            userData_ = new HashMap<>();
         }
         return userData_.put(key, data);
     }
@@ -871,46 +871,6 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
         }
 
         return newnode;
-    }
-
-    /**
-     * Returns the listener holder. If none exists, it will be create in a thread-safe
-     * manner.
-     *
-     * @return an instance of CopyOnWriteArrayList for characterDataListeners_
-     */
-    private CopyOnWriteArrayList<CharacterDataChangeListener> getCharacterDataListeners() {
-        if (this.characterDataListeners_ == null) {
-            // only now we have something expensive going on
-            synchronized (this) {
-                // still null? create it
-                if (this.characterDataListeners_ == null) {
-                    this.characterDataListeners_ = new CopyOnWriteArrayList<>();
-                }
-            }
-        }
-        // because our field is volatile, we see it when we arrive here
-        return this.characterDataListeners_;
-    }
-
-    /**
-     * Returns the listener holder. If none exists, it will be create in a thread-safe
-     * manner.
-     *
-     * @return an instance of CopyOnWriteArrayList for domListeners_
-     */
-    private CopyOnWriteArrayList<DomChangeListener> getDomListeners() {
-        if (this.domListeners_ == null) {
-            // only now we have something expensive going on
-            synchronized (this) {
-                // still null? create it
-                if (this.domListeners_ == null) {
-                    this.domListeners_ = new CopyOnWriteArrayList<>();
-                }
-            }
-        }
-        // because our field is volatile, we see it when we arrive here
-        return this.domListeners_;
     }
 
     /**
@@ -1710,7 +1670,14 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     public void addDomChangeListener(final DomChangeListener listener) {
         WebAssert.notNull("listener", listener);
-        getDomListeners().add(listener);
+
+        synchronized (listeners_lock_) {
+            if (domListeners_ == null) {
+                domListeners_ = new LinkedHashSet<>();
+            }
+            domListeners_.add(listener);
+            domListenersList_ = null;
+        }
     }
 
     /**
@@ -1722,7 +1689,13 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     public void removeDomChangeListener(final DomChangeListener listener) {
         WebAssert.notNull("listener", listener);
-        getDomListeners().remove(listener);
+
+        synchronized (listeners_lock_) {
+            if (domListeners_ != null) {
+                domListeners_.remove(listener);
+                domListenersList_ = null;
+            }
+        }
     }
 
     /**
@@ -1735,15 +1708,13 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     protected void fireNodeAdded(final DomChangeEvent event) {
         DomNode toInform = this;
-        final CopyOnWriteArrayList<DomChangeListener> listeners = getDomListeners();
-
         while (toInform != null) {
-            final Iterator<DomChangeListener> i = listeners.iterator();
-
-            while (i.hasNext()) {
-                i.next().nodeAdded(event);
+            final List<DomChangeListener> listeners = toInform.safeGetDomListeners();
+            if (listeners != null) {
+                for (final DomChangeListener listener : listeners) {
+                    listener.nodeAdded(event);
+                }
             }
-
             toInform = toInform.getParentNode();
         }
     }
@@ -1757,7 +1728,14 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     public void addCharacterDataChangeListener(final CharacterDataChangeListener listener) {
         WebAssert.notNull("listener", listener);
-        getCharacterDataListeners().add(listener);
+
+        synchronized (listeners_lock_) {
+            if (characterDataListeners_ == null) {
+                characterDataListeners_ = new LinkedHashSet<>();
+            }
+            characterDataListeners_.add(listener);
+            characterDataListenersList_ = null;
+        }
     }
 
     /**
@@ -1769,7 +1747,13 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     public void removeCharacterDataChangeListener(final CharacterDataChangeListener listener) {
         WebAssert.notNull("listener", listener);
-        getCharacterDataListeners().remove(listener);
+
+        synchronized (listeners_lock_) {
+            if (characterDataListeners_ != null) {
+                characterDataListeners_.remove(listener);
+                characterDataListenersList_ = null;
+            }
+        }
     }
 
     /**
@@ -1781,15 +1765,14 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     protected void fireCharacterDataChanged(final CharacterDataChangeEvent event) {
         DomNode toInform = this;
-        final CopyOnWriteArrayList<CharacterDataChangeListener> listeners = getCharacterDataListeners();
-
         while (toInform != null) {
-            final Iterator<CharacterDataChangeListener> i = listeners.iterator();
 
-            while (i.hasNext()) {
-                i.next().characterDataChanged(event);
+            final List<CharacterDataChangeListener> listeners = toInform.safeGetCharacterDataListeners();
+            if (listeners != null) {
+                for (final CharacterDataChangeListener listener : listeners) {
+                    listener.characterDataChanged(event);
+                }
             }
-
             toInform = toInform.getParentNode();
         }
     }
@@ -1804,16 +1787,38 @@ public abstract class DomNode implements Cloneable, Serializable, Node {
      */
     protected void fireNodeDeleted(final DomChangeEvent event) {
         DomNode toInform = this;
-        final CopyOnWriteArrayList<DomChangeListener> listeners = getDomListeners();
-
         while (toInform != null) {
-            final Iterator<DomChangeListener> i = listeners.iterator();
-
-            while (i.hasNext()) {
-                i.next().nodeDeleted(event);
+            final List<DomChangeListener> listeners = toInform.safeGetDomListeners();
+            if (listeners != null) {
+                for (final DomChangeListener listener : listeners) {
+                    listener.nodeDeleted(event);
+                }
             }
-
             toInform = toInform.getParentNode();
+        }
+    }
+
+    private List<DomChangeListener> safeGetDomListeners() {
+        synchronized (listeners_lock_) {
+            if (domListeners_ == null) {
+                return null;
+            }
+            if (domListenersList_ == null) {
+                domListenersList_ = new ArrayList<>(domListeners_);
+            }
+            return domListenersList_;
+        }
+    }
+
+    private List<CharacterDataChangeListener> safeGetCharacterDataListeners() {
+        synchronized (listeners_lock_) {
+            if (characterDataListeners_ == null) {
+                return null;
+            }
+            if (characterDataListenersList_ == null) {
+                characterDataListenersList_ = new ArrayList<>(characterDataListeners_);
+            }
+            return characterDataListenersList_;
         }
     }
 

--- a/src/main/java/org/htmlunit/html/HtmlButton.java
+++ b/src/main/java/org/htmlunit/html/HtmlButton.java
@@ -324,7 +324,7 @@ public class HtmlButton extends HtmlElement implements DisabledElement, Submitta
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, final String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
         if (NAME_ATTRIBUTE.equals(qualifiedNameLC)) {
             if (newNames_.isEmpty()) {
                 newNames_ = new HashSet<>();

--- a/src/main/java/org/htmlunit/html/HtmlCheckBoxInput.java
+++ b/src/main/java/org/htmlunit/html/HtmlCheckBoxInput.java
@@ -204,7 +204,7 @@ public class HtmlCheckBoxInput extends HtmlInput implements LabelableElement {
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, final String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
 
         if (VALUE_ATTRIBUTE.equals(qualifiedNameLC)) {
             super.setAttributeNS(namespaceURI, qualifiedNameLC, attributeValue, notifyAttributeChangeListeners,

--- a/src/main/java/org/htmlunit/html/HtmlElement.java
+++ b/src/main/java/org/htmlunit/html/HtmlElement.java
@@ -21,8 +21,6 @@ import static org.htmlunit.BrowserVersionFeatures.KEYBOARD_EVENT_SPECIAL_KEYPRES
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -148,7 +146,7 @@ public abstract class HtmlElement extends DomElement {
     protected static final String ATTRIBUTE_CHECKED = "checked";
 
     /** The listeners which are to be notified of attribute changes. */
-    private final Collection<HtmlAttributeChangeListener> attributeListeners_;
+    private final List<HtmlAttributeChangeListener> attributeListeners_ = new ArrayList<>();
 
     /** The owning form for lost form children. */
     private HtmlForm owningForm_;
@@ -182,7 +180,6 @@ public abstract class HtmlElement extends DomElement {
     protected HtmlElement(final String namespaceURI, final String qualifiedName, final SgmlPage page,
             final Map<String, DomAttr> attributes) {
         super(namespaceURI, qualifiedName, page, attributes);
-        attributeListeners_ = new LinkedHashSet<>();
     }
 
     /**
@@ -236,7 +233,7 @@ public abstract class HtmlElement extends DomElement {
      */
     protected static void notifyAttributeChangeListeners(final HtmlAttributeChangeEvent event,
             final HtmlElement element, final String oldAttributeValue, final boolean notifyMutationObservers) {
-        final Collection<HtmlAttributeChangeListener> listeners = element.attributeListeners_;
+        final List<HtmlAttributeChangeListener> listeners = element.attributeListeners_;
         if (ATTRIBUTE_NOT_DEFINED == oldAttributeValue) {
             synchronized (listeners) {
                 for (final HtmlAttributeChangeListener listener : listeners) {

--- a/src/main/java/org/htmlunit/html/HtmlImage.java
+++ b/src/main/java/org/htmlunit/html/HtmlImage.java
@@ -137,7 +137,7 @@ public class HtmlImage extends HtmlElement {
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
 
         final HtmlPage htmlPage = getHtmlPageOrNull();
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
         if (SRC_ATTRIBUTE.equals(qualifiedNameLC) && value != ATTRIBUTE_NOT_DEFINED && htmlPage != null) {
             final String oldValue = getAttributeNS(namespaceURI, qualifiedNameLC);
             if (!oldValue.equals(value)) {

--- a/src/main/java/org/htmlunit/html/HtmlInput.java
+++ b/src/main/java/org/htmlunit/html/HtmlInput.java
@@ -625,7 +625,7 @@ public abstract class HtmlInput extends HtmlElement implements DisabledElement, 
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, final String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
         if (NAME_ATTRIBUTE.equals(qualifiedNameLC)) {
             if (newNames_.isEmpty()) {
                 newNames_ = new HashSet<>();
@@ -1143,7 +1143,7 @@ public abstract class HtmlInput extends HtmlElement implements DisabledElement, 
     public final String getType() {
         final BrowserVersion browserVersion = getPage().getWebClient().getBrowserVersion();
         String type = getTypeAttribute();
-        type = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(type);
+        type = org.htmlunit.util.StringUtils.toRootLowerCase(type);
         return isSupported(type, browserVersion) ? type : "text";
     }
 
@@ -1167,11 +1167,11 @@ public abstract class HtmlInput extends HtmlElement implements DisabledElement, 
         final BrowserVersion browser = webClient.getBrowserVersion();
         if (!currentType.equalsIgnoreCase(newType)) {
             if (newType != null && browser.hasFeature(JS_INPUT_SET_TYPE_LOWERCASE)) {
-                newType = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(newType);
+                newType = org.htmlunit.util.StringUtils.toRootLowerCase(newType);
             }
 
             if (!isSupported(org.htmlunit.util.StringUtils
-                                    .toRootLowerCaseWithCache(newType), browser)) {
+                                    .toRootLowerCase(newType), browser)) {
                 if (setThroughAttribute) {
                     newType = "text";
                 }

--- a/src/main/java/org/htmlunit/html/HtmlPage.java
+++ b/src/main/java/org/htmlunit/html/HtmlPage.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -162,10 +163,8 @@ public class HtmlPage extends SgmlPage {
     private transient Charset originalCharset_;
     private final Object lock_ = new SerializableLock(); // used for synchronization
 
-    private Map<String, SortedSet<DomElement>> idMap_
-            = Collections.synchronizedMap(new HashMap<>());
-    private Map<String, SortedSet<DomElement>> nameMap_
-            = Collections.synchronizedMap(new HashMap<>());
+    private Map<String, SortedSet<DomElement>> idMap_ = new ConcurrentHashMap<>();
+    private Map<String, SortedSet<DomElement>> nameMap_ = new ConcurrentHashMap<>();
 
     private SortedSet<BaseFrameElement> frameElements_ = new TreeSet<>(documentPositionComparator);
     private int parserCount_;
@@ -1975,8 +1974,8 @@ public class HtmlPage extends SgmlPage {
         final HtmlPage result = (HtmlPage) super.clone();
         result.elementWithFocus_ = null;
 
-        result.idMap_ = Collections.synchronizedMap(new HashMap<>());
-        result.nameMap_ = Collections.synchronizedMap(new HashMap<>());
+        result.idMap_ = new ConcurrentHashMap<>();
+        result.nameMap_ = new ConcurrentHashMap<>();
 
         return result;
     }

--- a/src/main/java/org/htmlunit/html/HtmlPage.java
+++ b/src/main/java/org/htmlunit/html/HtmlPage.java
@@ -1994,9 +1994,11 @@ public class HtmlPage extends SgmlPage {
 
         // if deep, clone the kids too, and re initialize parts of the clone
         if (deep) {
-            synchronized (lock_) {
-                result.attributeListeners_ = null;
-            }
+            // this was previously synchronized but that makes not sense, why
+            // lock the source against a copy only one has a reference too,
+            // because result is a local reference
+            result.attributeListeners_ = null;
+
             result.selectionRanges_ = new ArrayList<>(3);
             result.afterLoadActions_ = new ArrayList<>();
             result.frameElements_ = new TreeSet<>(documentPositionComparator);

--- a/src/main/java/org/htmlunit/html/HtmlPage.java
+++ b/src/main/java/org/htmlunit/html/HtmlPage.java
@@ -2000,7 +2000,8 @@ public class HtmlPage extends SgmlPage {
             result.attributeListeners_ = null;
 
             result.selectionRanges_ = new ArrayList<>(3);
-            result.afterLoadActions_ = new ArrayList<>();
+            // the original one is synchronized so we should do that here too, shouldn't we?
+            result.afterLoadActions_ = Collections.synchronizedList(new ArrayList<>());
             result.frameElements_ = new TreeSet<>(documentPositionComparator);
             for (DomNode child = getFirstChild(); child != null; child = child.getNextSibling()) {
                 result.appendChild(child.cloneNode(true));

--- a/src/main/java/org/htmlunit/html/HtmlPage.java
+++ b/src/main/java/org/htmlunit/html/HtmlPage.java
@@ -596,7 +596,7 @@ public class HtmlPage extends SgmlPage {
     @Override
     public DomElement createElement(String tagName) {
         if (tagName.indexOf(':') == -1) {
-            tagName = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(tagName);
+            tagName = org.htmlunit.util.StringUtils.toRootLowerCase(tagName);
         }
         return getWebClient().getPageCreator().getHtmlParser().getFactory(tagName)
                     .createElementNS(this, null, tagName, null, true);

--- a/src/main/java/org/htmlunit/html/HtmlRadioButtonInput.java
+++ b/src/main/java/org/htmlunit/html/HtmlRadioButtonInput.java
@@ -273,7 +273,7 @@ public class HtmlRadioButtonInput extends HtmlInput implements LabelableElement 
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, final String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
 
         if (VALUE_ATTRIBUTE.equals(qualifiedNameLC)) {
             super.setAttributeNS(namespaceURI, qualifiedNameLC, attributeValue, notifyAttributeChangeListeners,

--- a/src/main/java/org/htmlunit/html/HtmlScript.java
+++ b/src/main/java/org/htmlunit/html/HtmlScript.java
@@ -157,7 +157,7 @@ public class HtmlScript extends HtmlElement implements ScriptElement {
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, final String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
         // special additional processing for the 'src'
         if (namespaceURI != null || !SRC_ATTRIBUTE.equals(qualifiedNameLC)) {
             super.setAttributeNS(namespaceURI, qualifiedNameLC, attributeValue, notifyAttributeChangeListeners,

--- a/src/main/java/org/htmlunit/html/HtmlSelect.java
+++ b/src/main/java/org/htmlunit/html/HtmlSelect.java
@@ -666,7 +666,7 @@ public class HtmlSelect extends HtmlElement implements DisabledElement, Submitta
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, final String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
         if (DomElement.NAME_ATTRIBUTE.equals(qualifiedNameLC)) {
             if (newNames_.isEmpty()) {
                 newNames_ = new HashSet<>();

--- a/src/main/java/org/htmlunit/html/HtmlTextArea.java
+++ b/src/main/java/org/htmlunit/html/HtmlTextArea.java
@@ -541,7 +541,7 @@ public class HtmlTextArea extends HtmlElement implements DisabledElement, Submit
     @Override
     protected void setAttributeNS(final String namespaceURI, final String qualifiedName, final String attributeValue,
             final boolean notifyAttributeChangeListeners, final boolean notifyMutationObservers) {
-        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(qualifiedName);
+        final String qualifiedNameLC = org.htmlunit.util.StringUtils.toRootLowerCase(qualifiedName);
         if (DomElement.NAME_ATTRIBUTE.equals(qualifiedNameLC)) {
             if (newNames_.isEmpty()) {
                 newNames_ = new HashSet<>();

--- a/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
+++ b/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
@@ -526,6 +526,9 @@ final class HtmlUnitNekoDOMBuilder extends AbstractSAXParser
     }
 
     private static boolean isTableCell(final String nodeName) {
+        if (nodeName == null || nodeName.length() != 2) {
+            return false;
+        }
         return "td".equals(nodeName) || "th".equals(nodeName);
     }
 

--- a/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
+++ b/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoDOMBuilder.java
@@ -26,12 +26,9 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.htmlunit.BrowserVersion;
 import org.htmlunit.ObjectInstantiationException;
@@ -76,6 +73,7 @@ import org.htmlunit.html.parser.HTMLParserDOMBuilder;
 import org.htmlunit.html.parser.HTMLParserListener;
 import org.htmlunit.javascript.host.html.HTMLBodyElement;
 import org.htmlunit.javascript.host.html.HTMLDocument;
+import org.htmlunit.util.StringUtils;
 import org.w3c.dom.Node;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -329,7 +327,7 @@ final class HtmlUnitNekoDOMBuilder extends AbstractSAXParser
         }
         handleCharacters();
 
-        final String tagLower = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(localName);
+        final String tagLower = org.htmlunit.util.StringUtils.toRootLowerCase(localName);
         if (page_.isParsingHtmlSnippet() && ("html".equals(tagLower) || "body".equals(tagLower))) {
             // we have to push the current node on the stack to make sure
             // the endElement call is able to remove a node from the stack
@@ -547,7 +545,7 @@ final class HtmlUnitNekoDOMBuilder extends AbstractSAXParser
     public void endElement(final String namespaceURI, final String localName, final String qName)
         throws SAXException {
 
-        final String tagLower = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(localName);
+        final String tagLower = org.htmlunit.util.StringUtils.toRootLowerCase(localName);
 
         handleCharacters();
 
@@ -809,9 +807,9 @@ final class HtmlUnitNekoDOMBuilder extends AbstractSAXParser
 
     private static void copyAttributes(final DomElement to, final XMLAttributes attrs) {
         final int length = attrs.getLength();
+
         for (int i = 0; i < length; i++) {
-            final String attrName = org.htmlunit.util.StringUtils
-                                        .toRootLowerCaseWithCache(attrs.getLocalName(i));
+            final String attrName = StringUtils.toRootLowerCase(attrs.getLocalName(i));
             if (to.getAttributes().getNamedItem(attrName) == null) {
                 to.setAttribute(attrName, attrs.getValue(i));
                 if (attrName.startsWith("on") && to.getPage().getWebClient().isJavaScriptEngineEnabled()

--- a/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoHtmlParser.java
+++ b/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoHtmlParser.java
@@ -284,7 +284,7 @@ public final class HtmlUnitNekoHtmlParser implements HTMLParser {
             String tagName = qualifiedName;
             final int index = tagName.indexOf(':');
             if (index == -1) {
-                tagName = StringUtils.toRootLowerCaseWithCache(tagName);
+                tagName = StringUtils.toRootLowerCase(tagName);
             }
             else {
                 tagName = tagName.substring(index + 1);

--- a/src/main/java/org/htmlunit/javascript/host/Element.java
+++ b/src/main/java/org/htmlunit/javascript/host/Element.java
@@ -141,7 +141,7 @@ public class Element extends Node {
         //Should be called only on construction.
         final DomElement htmlElt = (DomElement) domNode;
         for (final DomAttr attr : htmlElt.getAttributesMap().values()) {
-            final String eventName = StringUtils.toRootLowerCaseWithCache(attr.getName());
+            final String eventName = StringUtils.toRootLowerCase(attr.getName());
             if (eventName.startsWith("on")) {
                 createEventHandler(eventName.substring(2), attr.getValue());
             }
@@ -236,7 +236,7 @@ public class Element extends Node {
         final boolean caseSensitive;
         final DomNode dom = getDomNodeOrNull();
         if (dom == null) {
-            searchTagName = StringUtils.toRootLowerCaseWithCache(tagName);
+            searchTagName = StringUtils.toRootLowerCase(tagName);
             caseSensitive = false;
         }
         else {
@@ -246,7 +246,7 @@ public class Element extends Node {
                 caseSensitive = true;
             }
             else {
-                searchTagName = StringUtils.toRootLowerCaseWithCache(tagName);
+                searchTagName = StringUtils.toRootLowerCase(tagName);
                 caseSensitive = false;
             }
         }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLBodyElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLBodyElement.java
@@ -67,7 +67,7 @@ public class HTMLBodyElement extends HTMLElement {
     public void createEventHandlerFromAttribute(final String attributeName, final String value) {
         // when many body tags are found while parsing, attributes of
         // different tags are added and should create an event handler when needed
-        if (StringUtils.toRootLowerCaseWithCache(attributeName).startsWith("on")) {
+        if (StringUtils.toRootLowerCase(attributeName).startsWith("on")) {
             createEventHandler(attributeName.substring(2), value);
         }
     }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLDocument.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLDocument.java
@@ -818,7 +818,7 @@ public class HTMLDocument extends Document {
         String name = attributeName;
         if (StringUtils.isNotEmpty(name)
                 && getBrowserVersion().hasFeature(JS_DOCUMENT_CREATE_ATTRUBUTE_LOWER_CASE)) {
-            name = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(name);
+            name = org.htmlunit.util.StringUtils.toRootLowerCase(name);
         }
 
         return super.createAttribute(name);

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLElement.java
@@ -515,13 +515,13 @@ public class HTMLElement extends Element {
             if (prefix != null) {
                 // create string builder only if needed (performance)
                 final StringBuilder localName = new StringBuilder(
-                                org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(prefix))
+                                org.htmlunit.util.StringUtils.toRootLowerCase(prefix))
                     .append(':')
                     .append(org.htmlunit.util.StringUtils
-                                .toRootLowerCaseWithCache(domNode.getLocalName()));
+                                .toRootLowerCase(domNode.getLocalName()));
                 return localName.toString();
             }
-            return org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(domNode.getLocalName());
+            return org.htmlunit.util.StringUtils.toRootLowerCase(domNode.getLocalName());
         }
         return domNode.getLocalName();
     }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLSpanElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLSpanElement.java
@@ -63,7 +63,7 @@ public class HTMLSpanElement extends HTMLElement {
         super.setDomNode(domNode);
         final BrowserVersion browser = getBrowserVersion();
         if (browser.hasFeature(HTMLBASEFONT_END_TAG_FORBIDDEN)) {
-            switch (StringUtils.toRootLowerCaseWithCache(domNode.getLocalName())) {
+            switch (StringUtils.toRootLowerCase(domNode.getLocalName())) {
                 case "basefont":
                 case "keygen":
                     endTagForbidden_ = true;

--- a/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
@@ -976,7 +976,7 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
                 for (final Entry<String, String> header
                         : new TreeMap<>(webRequest_.getAdditionalHeaders()).entrySet()) {
                     final String name = org.htmlunit.util.StringUtils
-                                            .toRootLowerCaseWithCache(header.getKey());
+                                            .toRootLowerCase(header.getKey());
                     if (isPreflightHeader(name, header.getValue())) {
                         if (builder.length() != 0) {
                             builder.append(',');
@@ -1177,7 +1177,7 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
             if (HttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.equalsIgnoreCase(pair.getName())) {
                 String value = pair.getValue();
                 if (value != null) {
-                    value = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(value);
+                    value = org.htmlunit.util.StringUtils.toRootLowerCase(value);
                     final String[] values = org.htmlunit.util.StringUtils.splitAtComma(value);
                     for (String part : values) {
                         part = part.trim();
@@ -1190,7 +1190,7 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
         }
 
         for (final Entry<String, String> header : webRequest_.getAdditionalHeaders().entrySet()) {
-            final String key = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(header.getKey());
+            final String key = org.htmlunit.util.StringUtils.toRootLowerCase(header.getKey());
             if (isPreflightHeader(key, header.getValue())
                     && !accessControlValues.contains(key)) {
                 return false;
@@ -1252,7 +1252,7 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
      * @return {@code true} if the header can be set from JavaScript
      */
     static boolean isAuthorizedHeader(final String name) {
-        final String nameLowerCase = org.htmlunit.util.StringUtils.toRootLowerCaseWithCache(name);
+        final String nameLowerCase = org.htmlunit.util.StringUtils.toRootLowerCase(name);
         if (PROHIBITED_HEADERS_.contains(nameLowerCase)) {
             return false;
         }

--- a/src/main/java/org/htmlunit/javascript/host/xml/XMLSerializer.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/XMLSerializer.java
@@ -224,7 +224,7 @@ public class XMLSerializer extends HtmlUnitScriptable {
             }
         }
         if (!startTagClosed) {
-            final String tagName = StringUtils.toRootLowerCaseWithCache(nodeName);
+            final String tagName = StringUtils.toRootLowerCase(nodeName);
             if (NON_EMPTY_TAGS.contains(tagName)) {
                 builder.append("></").append(nodeName).append('>');
             }

--- a/src/main/java/org/htmlunit/svg/SvgElementFactory.java
+++ b/src/main/java/org/htmlunit/svg/SvgElementFactory.java
@@ -61,7 +61,7 @@ public class SvgElementFactory implements ElementFactory {
         try {
             for (final Class<?> klass : CLASSES_) {
                 final String key = klass.getField("TAG_NAME").get(null).toString();
-                ELEMENTS_.put(StringUtils.toRootLowerCaseWithCache(key), klass);
+                ELEMENTS_.put(StringUtils.toRootLowerCase(key), klass);
             }
         }
         catch (final Exception e) {
@@ -94,7 +94,7 @@ public class SvgElementFactory implements ElementFactory {
             final Attributes attributes, final boolean checkBrowserCompatibility) {
 
         final Map<String, DomAttr> attributeMap = toMap(page, attributes);
-        qualifiedNameLC = StringUtils.toRootLowerCaseWithCache(qualifiedNameLC);
+        qualifiedNameLC = StringUtils.toRootLowerCase(qualifiedNameLC);
         String tagNameLC = qualifiedNameLC;
         if (tagNameLC.indexOf(':') != -1) {
             tagNameLC = tagNameLC.substring(tagNameLC.indexOf(':') + 1);

--- a/src/main/java/org/htmlunit/util/MimeType.java
+++ b/src/main/java/org/htmlunit/util/MimeType.java
@@ -59,12 +59,11 @@ public final class MimeType {
     private static final FastHashMap<String, Boolean> lookupMap = new FastHashMap<>(2 * 16 + 1, 0.7f);
 
     static {
-        lookupMap.put("application/ecmascript", true);
-        lookupMap.put(APPLICATION_JAVASCRIPT, true);
+        lookupMap.put("application/javascript", true);
         lookupMap.put("application/x-ecmascript", true);
         lookupMap.put("application/x-javascript", true);
         lookupMap.put("text/ecmascript", true);
-        lookupMap.put("text/javascript", true);
+        lookupMap.put("application/ecmascript", true);
         lookupMap.put("text/javascript1.0", true);
         lookupMap.put("text/javascript1.1", true);
         lookupMap.put("text/javascript1.2", true);
@@ -94,7 +93,7 @@ public final class MimeType {
         if (mimeType == null) {
             return false;
         }
-        final String mimeTypeLC = StringUtils.toRootLowerCaseWithCache(mimeType);
+        final String mimeTypeLC = StringUtils.toRootLowerCase(mimeType);
 
         return TEXT_JAVASCRIPT.equals(mimeTypeLC)
                 || "application/javascript".equals(mimeTypeLC)

--- a/src/main/java/org/htmlunit/util/OrderedFastHashMap.java
+++ b/src/main/java/org/htmlunit/util/OrderedFastHashMap.java
@@ -139,8 +139,15 @@ public class OrderedFastHashMap<K, V> implements Map<K, V> {
         }
 
         // we have not found it, search longer
+        final int originalPtr = ptr;
         while (true) {
             ptr = (ptr + 2) & (length - 1); // that's next index
+
+            // if we searched the entire array, we can stop
+            if (originalPtr == ptr) {
+                return null;
+            }
+
             k = this.mapData_[ptr];
 
             if (k == FREE_KEY_) {
@@ -166,7 +173,7 @@ public class OrderedFastHashMap<K, V> implements Map<K, V> {
      */
     private V put(final K key, final V value, final Position listPosition) {
         if (mapSize_ >= mapThreshold_) {
-            rehash(this.mapData_.length == 0 ? 2 : this.mapData_.length << 1);
+            rehash(this.mapData_.length == 0 ? 4 : this.mapData_.length << 1);
         }
 
         int ptr = getStartIndex(key) << 1;
@@ -915,7 +922,7 @@ public class OrderedFastHashMap<K, V> implements Map<K, V> {
                 mapData_ != null ? Arrays.asList(mapData_).subList(0, Math.min(mapData_.length, maxLen)) : null,
                         FILLFACTOR_, mapThreshold_, mapSize_,
                         orderedList_ != null
-                                ? Arrays.toString(Arrays.copyOf(orderedList_, Math.min(orderedList_.length, maxLen)))
+                        ? Arrays.toString(Arrays.copyOf(orderedList_, Math.min(orderedList_.length, maxLen)))
                                 : null,
                                 orderedListSize_);
     }

--- a/src/main/java/org/htmlunit/util/OrderedFastHashMap.java
+++ b/src/main/java/org/htmlunit/util/OrderedFastHashMap.java
@@ -1,0 +1,988 @@
+/*
+ * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Simple and efficient linked map or better ordered map implementation to
+ * replace the default linked list which is heavy.
+ *
+ * This map does not support null and it is not thread-safe. It implements the
+ * map interface but only for compatibility reason in the sense of replacing a
+ * regular map. Iterator and streaming methods are either not implemented or
+ * less efficient.
+ *
+ * It goes the extra mile to avoid the overhead of wrapper objects.
+ *
+ * Because you typically know what you do, we run minimal index checks only and
+ * rely on the default exceptions by Java. Why should we do things twice?
+ *
+ * Important Note: This is meant for small maps because to save on memory
+ * allocation and churn, we are not keeping a wrapper for a reference from the
+ * map to the list, only from the list to the map. Hence when you remove a key,
+ * we have to iterate the entire list. Mostly, half of it most likely, but still
+ * expensive enough. When you have something small like 10 to 20 entries, this
+ * won't matter that much especially when a remove might be a rare event.
+ *
+ * This is based on FashHashMap from XLT which is based on a version from:
+ * https://github.com/mikvor/hashmapTest/blob/master/src/main/java/map/objobj/ObjObjMap.java
+ * No concrete license specified at the source. The project is public domain.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ *
+ * @author Ren&eacute; Schwietzke
+ */
+public class OrderedFastHashMap<K, V> implements Map<K, V> {
+    // our placeholders in the map
+    private static Object FREE_KEY_ = null;
+    private static Object REMOVED_KEY_ = new Object();
+
+    // Fill factor, must be between (0 and 1)
+    private static final double FILLFACTOR_ = 0.7d;
+
+    // The map with the key value pairs */
+    private Object[] mapData_;
+
+    // We will resize a map once it reaches this size
+    private int mapThreshold_;
+
+    // Current map size
+    private int mapSize_;
+
+    // the list to impose order, the list refers to the key and value
+    // position in the map, hence needs an update every time the
+    // map sees an update (in regards to positions).
+    private int[] orderedList_;
+
+    // the size of the orderedList, in case we proactivly sized
+    // it larger
+    private int orderedListSize_;
+
+    /**
+     * Default constructor which create an ordered map with default size.
+     */
+    public OrderedFastHashMap() {
+        this(8);
+    }
+
+    /**
+     * Custom constructor to get a map with a custom size and fill factor. We are
+     * not spending time on range checks, rather use a default if things are wrong.
+     *
+     * @param size the size to use, must 0 or positive, negative values default to 0
+     */
+    public OrderedFastHashMap(final int size) {
+        if (size > 0) {
+            final int capacity = arraySize(size, FILLFACTOR_);
+
+            this.mapData_ = new Object[capacity << 1];
+            this.mapThreshold_ = (int) (capacity * FILLFACTOR_);
+
+            this.orderedList_ = new int[capacity];
+        }
+        else {
+            this.mapData_ = new Object[0];
+            this.mapThreshold_ = 0;
+
+            this.orderedList_ = new int[0];
+        }
+    }
+
+    /**
+     * Get a value for a key, any key type is permitted due to
+     * the nature of the Map interface.
+     *
+     * @param key the key
+     * @return the value or null, if the key does not exist
+     */
+    @Override
+    public V get(final Object key) {
+        final int length = this.mapData_.length;
+
+        // nothing in it
+        if (length == 0) {
+            return null;
+        }
+
+        int ptr = (key.hashCode() & ((length >> 1) - 1)) << 1;
+        Object k = mapData_[ptr];
+
+        if (k == FREE_KEY_) {
+            return null; // end of chain already
+        }
+
+        // we checked FREE
+        if (k.hashCode() == key.hashCode() && k.equals(key)) {
+            return (V) this.mapData_[ptr + 1];
+        }
+
+        // we have not found it, search longer
+        while (true) {
+            ptr = (ptr + 2) & (length - 1); // that's next index
+            k = this.mapData_[ptr];
+
+            if (k == FREE_KEY_) {
+                return null;
+            }
+
+            if (k != REMOVED_KEY_) {
+                if (k.hashCode() == key.hashCode() && k.equals(key)) {
+                    return (V) this.mapData_[ptr + 1];
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds a key and value to the internal position structure
+     *
+     * @param key the key
+     * @param value the value to store
+     * @param listPosition defines where to add the new key/value pair
+     *
+     * @return the old value or null if they key was not known before
+     */
+    private V put(final K key, final V value, final Position listPosition) {
+        if (mapSize_ >= mapThreshold_) {
+            rehash(this.mapData_.length == 0 ? 2 : this.mapData_.length << 1);
+        }
+
+        int ptr = getStartIndex(key) << 1;
+        Object k = mapData_[ptr];
+
+        if (k == FREE_KEY_) {
+            // end of chain already
+            mapData_[ptr] = key;
+            mapData_[ptr + 1] = value;
+
+            // ok, remember position, it is a new entry
+            orderedListAdd(listPosition, ptr);
+
+            mapSize_++;
+
+            return null;
+        }
+        else if (k.equals(key)) {
+            // we check FREE and REMOVED prior to this call
+            final Object ret = mapData_[ptr + 1];
+            mapData_[ptr + 1] = value;
+
+            /// existing entry, no need to update the position
+
+            return (V) ret;
+        }
+
+        int firstRemoved = -1;
+        if (k == REMOVED_KEY_) {
+            firstRemoved = ptr; // we may find a key later
+        }
+
+        while (true) {
+            ptr = (ptr + 2) & (this.mapData_.length - 1); // that's next index calculation
+            k = mapData_[ptr];
+
+            if (k == FREE_KEY_) {
+                if (firstRemoved != -1) {
+                    ptr = firstRemoved;
+                }
+                mapData_[ptr] = key;
+                mapData_[ptr + 1] = value;
+
+                // ok, remember position, it is a new entry
+                orderedListAdd(listPosition, ptr);
+
+                mapSize_++;
+
+                return null;
+            }
+            else if (k.equals(key)) {
+                final Object ret = mapData_[ptr + 1];
+                mapData_[ptr + 1] = value;
+
+                // same key, different value, this does not change the order
+
+                return (V) ret;
+            }
+            else if (k == REMOVED_KEY_) {
+                if (firstRemoved == -1) {
+                    firstRemoved = ptr;
+                }
+            }
+        }
+    }
+
+    /**
+     * Remove a key from the map. Returns the stored value or
+     * null of the key is not known.
+     *
+     * @param key the key to remove
+     * @return the stored value or null if the key does not exist
+     */
+    @Override
+    public V remove(final Object key) {
+        final int length = this.mapData_.length;
+        // it is empty
+        if (length == 0) {
+            return null;
+        }
+
+        int ptr = getStartIndex(key) << 1;
+        Object k = this.mapData_[ptr];
+
+        if (k == FREE_KEY_) {
+            return null; // end of chain already
+        }
+        else if (k.equals(key)) {
+            // we check FREE and REMOVED prior to this call
+            this.mapSize_--;
+
+            if (this.mapData_[(ptr + 2) & (length - 1)] == FREE_KEY_) {
+                this.mapData_[ptr] = FREE_KEY_;
+            }
+            else {
+                this.mapData_[ptr] = REMOVED_KEY_;
+            }
+
+            final V ret = (V) this.mapData_[ptr + 1];
+            this.mapData_[ptr + 1] = null;
+
+            // take this out of the list
+            orderedListRemove(ptr);
+
+            return ret;
+        }
+
+        while (true) {
+            ptr = (ptr + 2) & (length - 1); // that's next index calculation
+            k = this.mapData_[ptr];
+
+            if (k == FREE_KEY_) {
+                return null;
+            }
+            else if (k.equals(key)) {
+                this.mapSize_--;
+                if (this.mapData_[(ptr + 2) & (length - 1)] == FREE_KEY_) {
+                    this.mapData_[ptr] = FREE_KEY_;
+                }
+                else {
+                    this.mapData_[ptr] = REMOVED_KEY_;
+                }
+
+                final V ret = (V) this.mapData_[ptr + 1];
+                this.mapData_[ptr + 1] = null;
+
+                // take this out of the list
+                orderedListRemove(ptr);
+
+                return ret;
+            }
+        }
+    }
+
+    /**
+     * Returns the size of the map, effectively the number of entries.
+     *
+     * @return the size of the map
+     */
+    public int size() {
+        return mapSize_;
+    }
+
+    /**
+     * Rehash the map.
+     *
+     * @param newCapacity the new size of the map
+     */
+    private void rehash(final int newCapacity) {
+        this.mapThreshold_ = (int) (newCapacity / 2 * FILLFACTOR_);
+
+        final Object[] oldData = this.mapData_;
+
+        this.mapData_ = new Object[newCapacity];
+
+        // we just have to grow it and not touch it at all after that,
+        // just use it as source for the new map via the old
+        final int[] oldOrderedList = this.orderedList_;
+        final int oldOrderedListSize = this.orderedListSize_;
+        this.orderedList_ = new int[newCapacity];
+
+        this.mapSize_ = 0;
+        this.orderedListSize_ = 0;
+
+        // we use our ordered list as source and the old
+        // array as reference
+        // we basically rebuild the map and the ordering
+        // from scratch
+        for (int i = 0; i < oldOrderedListSize; i++) {
+            final int pos = oldOrderedList[i];
+
+            // get us the old data
+            final K key = (K) oldData[pos];
+            final V value = (V) oldData[pos + 1];
+
+            // write the old to the new map without updating
+            // the positioning
+            put(key, value, Position.LAST);
+        }
+    }
+
+    /**
+     * Returns a list of all keys in order of addition.
+     * This is an expensive operation, because we get a static
+     * list back that is not backed by the implementation. Changes
+     * to the returned list are not reflected in the map.
+     *
+     * @return a list of keys as inserted into the map
+     */
+    public List<K> keys() {
+        final List<K> result = new ArrayList<>(this.orderedListSize_);
+
+        for (int i = 0; i < this.orderedListSize_; i++) {
+            final int pos = this.orderedList_[i];
+            final Object o = this.mapData_[pos];
+            result.add((K) o);
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns a list of all values ordered by when the key was
+     * added. This is an expensive operation, because we get a static
+     * list back that is not backed by the implementation. Changes
+     * to the returned list are not reflected in the map.
+     *
+     * @return a list of values
+     */
+    public List<V> values() {
+        final List<V> result = new ArrayList<>(this.orderedListSize_);
+
+        for (int i = 0; i < this.orderedListSize_; i++) {
+            final int pos = this.orderedList_[i];
+            final Object o = this.mapData_[pos + 1];
+            result.add((V) o);
+        }
+
+        return result;
+    }
+
+    /**
+     * Clears the map, reuses the data structure by clearing it out. It won't shrink
+     * the underlying arrays!
+     */
+    public void clear() {
+        this.mapSize_ = 0;
+        this.orderedListSize_ = 0;
+        Arrays.fill(this.mapData_, FREE_KEY_);
+        // Arrays.fill(this.orderedList, 0);
+    }
+
+    /**
+     * Get us the start index from where we search or insert into the map
+     *
+     * @param key the key to calculate the position for
+     * @return the start position
+     */
+    private int getStartIndex(final Object key) {
+        // key is not null here
+        return key.hashCode() & ((this.mapData_.length >> 1) - 1);
+    }
+
+    /**
+     * Return the least power of two greater than or equal to the specified value.
+     *
+     * <p>
+     * Note that this function will return 1 when the argument is 0.
+     *
+     * @param x a long integer smaller than or equal to 2<sup>62</sup>.
+     * @return the least power of two greater than or equal to the specified value.
+     */
+    private static long nextPowerOfTwo(final long x) {
+        if (x == 0) {
+            return 1;
+        }
+
+        long r = x - 1;
+        r |= r >> 1;
+        r |= r >> 2;
+        r |= r >> 4;
+        r |= r >> 8;
+        r |= r >> 16;
+
+        return (r | r >> 32) + 1;
+    }
+
+    /**
+     * Returns the least power of two smaller than or equal to 2<sup>30</sup> and
+     * larger than or equal to <code>Math.ceil( expected / f )</code>.
+     *
+     * @param expected the expected number of elements in a hash table.
+     * @param f        the load factor.
+     * @return the minimum possible size for a backing array.
+     * @throws IllegalArgumentException if the necessary size is larger than
+     *                                  2<sup>30</sup>.
+     */
+    private static int arraySize(final int expected, final double f) {
+        final long s = Math.max(2, nextPowerOfTwo((long) Math.ceil(expected / f)));
+
+        if (s > (1 << 30)) {
+            throw new IllegalArgumentException(
+                    "Too large (" + expected + " expected elements with load factor " + f + ")");
+        }
+        return (int) s;
+    }
+
+    /**
+     * Returns an entry consisting of key and value at a given position.
+     * This position relates to the ordered key list that maintain the
+     * addition order for this map.
+     *
+     * @param index the position to fetch
+     * @return an entry of key and value
+     * @throws IndexOutOfBoundsException when the ask for the position is invalid
+     */
+    public Entry<K, V> getEntry(final int index) {
+        if (index < 0 || index >= this.orderedListSize_) {
+            throw new IndexOutOfBoundsException(String.format("Index: %s, Size: %s", index, this.orderedListSize_));
+        }
+
+        final int pos = this.orderedList_[index];
+        return new Entry(this.mapData_[pos], this.mapData_[pos + 1]);
+    }
+
+    /**
+     * Returns the key at a certain position of the ordered list that
+     * keeps the addition order of this map.
+     *
+     * @param index the position to fetch
+     * @return the key at this position
+     * @throws IndexOutOfBoundsException when the ask for the position is invalid
+     */
+    public K getKey(final int index) {
+        if (index < 0 || index >= this.orderedListSize_) {
+            throw new IndexOutOfBoundsException(String.format("Index: %s, Size: %s", index, this.orderedListSize_));
+        }
+
+        final int pos = this.orderedList_[index];
+        return (K) this.mapData_[pos];
+    }
+
+    /**
+     * Returns the value at a certain position of the ordered list that
+     * keeps the addition order of this map.
+     *
+     * @param index the position to fetch
+     * @return the value at this position
+     * @throws IndexOutOfBoundsException when the ask for the position is invalid
+     */
+    public V getValue(final int index) {
+        if (index < 0 || index >= this.orderedListSize_) {
+            throw new IndexOutOfBoundsException(String.format("Index: %s, Size: %s", index, this.orderedListSize_));
+        }
+
+        final int pos = this.orderedList_[index];
+        return (V) this.mapData_[pos + 1];
+    }
+
+    /**
+     * Removes a key and value from this map based on the position
+     * in the backing list, rather by key as usual.
+     *
+     * @param index the position to remove the data from
+     * @return the value stored
+     * @throws IndexOutOfBoundsException when the ask for the position is invalid
+     */
+    public V remove(final int index) {
+        if (index < 0 || index >= this.orderedListSize_) {
+            throw new IndexOutOfBoundsException(String.format("Index: %s, Size: %s", index, this.orderedListSize_));
+        }
+
+        final int pos = this.orderedList_[index];
+        final K key = (K) this.mapData_[pos];
+
+        return remove(key);
+    }
+
+    @Override
+    public V put(final K key, final V value) {
+        return this.put(key, value, Position.LAST);
+    }
+
+    public V addFirst(final K key, final V value) {
+        return this.put(key, value, Position.FIRST);
+    }
+
+    public V add(final K key, final V value) {
+        return this.put(key, value, Position.LAST);
+    }
+
+    public V addLast(final K key, final V value) {
+        return this.put(key, value, Position.LAST);
+    }
+
+    public V getFirst() {
+        return getValue(0);
+    }
+
+    public V getLast() {
+        return getValue(this.orderedListSize_ - 1);
+    }
+
+    public V removeFirst() {
+        if (this.orderedListSize_ > 0) {
+            final int pos = this.orderedList_[0];
+            final K key = (K) this.mapData_[pos];
+            return remove(key);
+        }
+        else {
+            return null;
+        }
+    }
+
+    public V removeLast() {
+        if (this.orderedListSize_ > 0) {
+            final int pos = this.orderedList_[this.orderedListSize_ - 1];
+            final K key = (K) this.mapData_[pos];
+            return remove(key);
+        }
+        else {
+            return null;
+        }
+    }
+
+    /**
+     * Checks of a key is in the map.
+     *
+     * @param key the key to check
+     * @return true of the key is in the map, false otherwise
+     */
+    @Override
+    public boolean containsKey(final Object key) {
+        return get(key) != null;
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        // that is expensive, we have to iterate everything
+        for (int i = 0; i < this.orderedListSize_; i++) {
+            final int pos = this.orderedList_[i] + 1;
+            final Object v = this.mapData_[pos];
+
+            // do we match?
+            if (v == value || v.equals(value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.mapSize_ == 0;
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        final Set<Map.Entry<K, V>> set = new OrderedEntrySet<>(this);
+        return set;
+    }
+
+    @Override
+    public Set<K> keySet() {
+        final Set<K> set = new OrderedKeySet<>(this);
+        return set;
+    }
+
+    /**
+     * Just reverses the ordering of the map as created so far.
+     */
+    public void reverse() {
+        // In-place reversal
+        final int to = this.orderedListSize_ / 2;
+
+        for (int i = 0; i < to; i++) {
+            // Swapping the elements
+            final int j = this.orderedList_[i];
+            this.orderedList_[i] = this.orderedList_[this.orderedListSize_ - i - 1];
+            this.orderedList_[this.orderedListSize_ - i - 1] = j;
+        }
+    }
+
+    /**
+     * This set does not support any modifications through its interface. All such
+     * methods will throw {@link UnsupportedOperationException}.
+     */
+    static class OrderedEntrySet<K, V> implements Set<Map.Entry<K, V>> {
+        private final OrderedFastHashMap<K, V> backingMap_;
+
+        OrderedEntrySet(final OrderedFastHashMap<K, V> backingMap) {
+            this.backingMap_ = backingMap;
+        }
+
+        @Override
+        public int size() {
+            return this.backingMap_.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.backingMap_.isEmpty();
+        }
+
+        @Override
+        public boolean contains(final Object o) {
+            if (o instanceof Map.Entry) {
+                final Map.Entry ose = (Map.Entry) o;
+                final Object k = ose.getKey();
+                final Object v = ose.getValue();
+
+                final Object value = this.backingMap_.get(k);
+                if (value != null) {
+                    return v.equals(value);
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public Object[] toArray() {
+            final Object[] array = new Object[this.backingMap_.orderedListSize_];
+            return toArray(array);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T[] toArray(final T[] a) {
+            final T[] array;
+            if (a.length >= this.backingMap_.orderedListSize_) {
+                array = a;
+            }
+            else {
+                array = (T[]) java.lang.reflect.Array.newInstance(a.getClass().getComponentType(),
+                        this.backingMap_.orderedListSize_);
+            }
+
+            for (int i = 0; i < this.backingMap_.orderedListSize_; i++) {
+                array[i] = (T) this.backingMap_.getEntry(i);
+            }
+
+            return (T[]) array;
+        }
+
+        @Override
+        public Iterator<Map.Entry<K, V>> iterator() {
+            return new OrderedEntryIterator();
+        }
+
+        @Override
+        public boolean add(final Map.Entry<K, V> e) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean remove(final Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean containsAll(final Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean addAll(final Collection<? extends Map.Entry<K, V>> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean retainAll(final Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeAll(final Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException();
+        }
+
+        class OrderedEntryIterator implements Iterator<Map.Entry<K, V>> {
+            private int pos_ = 0;
+
+            @Override
+            public boolean hasNext() {
+                return pos_ < backingMap_.orderedListSize_;
+            }
+
+            @Override
+            public Map.Entry<K, V> next() {
+                if (pos_ < backingMap_.orderedListSize_) {
+                    return backingMap_.getEntry(pos_++);
+                }
+                throw new NoSuchElementException();
+            }
+        }
+    }
+
+    static class OrderedKeySet<K, V> implements Set<K> {
+        private final OrderedFastHashMap<K, V> backingMap_;
+
+        OrderedKeySet(final OrderedFastHashMap<K, V> backingMap) {
+            this.backingMap_ = backingMap;
+        }
+
+        @Override
+        public int size() {
+            return this.backingMap_.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.backingMap_.isEmpty();
+        }
+
+        @Override
+        public boolean contains(final Object o) {
+            return this.backingMap_.containsKey(o);
+        }
+
+        @Override
+        public Object[] toArray() {
+            final Object[] array = new Object[this.backingMap_.orderedListSize_];
+            return toArray(array);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T[] toArray(final T[] a) {
+            final T[] array;
+
+            if (a.length >= this.backingMap_.orderedListSize_) {
+                array = a;
+            }
+            else {
+                array = (T[]) java.lang.reflect.Array.newInstance(a.getClass().getComponentType(),
+                        this.backingMap_.orderedListSize_);
+            }
+
+            for (int i = 0; i < this.backingMap_.orderedListSize_; i++) {
+                array[i] = (T) this.backingMap_.getKey(i);
+            }
+
+            return (T[]) array;
+        }
+
+        @Override
+        public Iterator<K> iterator() {
+            return new OrderedKeyIterator();
+        }
+
+        class OrderedKeyIterator implements Iterator<K> {
+            private int pos_ = 0;
+
+            @Override
+            public boolean hasNext() {
+                return this.pos_ < backingMap_.orderedListSize_;
+            }
+
+            @Override
+            public K next() {
+                if (this.pos_ < backingMap_.orderedListSize_) {
+                    return backingMap_.getKey(this.pos_++);
+                }
+                throw new NoSuchElementException();
+            }
+        }
+
+        @Override
+        public boolean add(final K e) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean remove(final Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean containsAll(final Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean addAll(final Collection<? extends K> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean retainAll(final Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeAll(final Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public void putAll(final Map<? extends K, ? extends V> src) {
+        if (src == this) {
+            throw new IllegalArgumentException("Cannot add myself");
+        }
+
+        for (final Map.Entry<? extends K, ? extends V> entry : src.entrySet()) {
+            put(entry.getKey(), entry.getValue(), Position.LAST);
+        }
+    }
+
+    private void orderedListAdd(final Position listPosition, final int position) {
+        // the list should still have room, otherwise the map was
+        // grown already and the ordering list with it
+        if (listPosition == Position.FIRST) {
+            System.arraycopy(this.orderedList_, 0, this.orderedList_, 1, this.orderedList_.length - 1);
+            this.orderedList_[0] = position;
+            this.orderedListSize_++;
+        }
+        else if (listPosition == Position.LAST) {
+            this.orderedList_[this.orderedListSize_] = position;
+            this.orderedListSize_++;
+        }
+        else {
+            // if none, we are rebuilding the map and don't have to do a thing
+        }
+    }
+
+    private void orderedListRemove(final int position) {
+        // find the positional information
+        int i = 0;
+        for ( ; i < this.orderedListSize_; i++) {
+            if (this.orderedList_[i] == position) {
+                this.orderedList_[i] = -1;
+                if (i < this.orderedListSize_) {
+                    // not the last element, compact
+                    System.arraycopy(this.orderedList_, i + 1, this.orderedList_, i, this.orderedListSize_ - i);
+                }
+                this.orderedListSize_--;
+
+                return;
+            }
+        }
+
+        if (i == this.orderedListSize_) {
+            throw new IllegalArgumentException(String.format("Position %s was not in order list", position));
+        }
+    }
+
+    @Override
+    public String toString() {
+        final int maxLen = 10;
+
+        return String.format(
+                "mapData=%s, mapFillFactor=%s, mapThreshold=%s, mapSize=%s,%norderedList=%s, orderedListSize=%s",
+                mapData_ != null ? Arrays.asList(mapData_).subList(0, Math.min(mapData_.length, maxLen)) : null,
+                        FILLFACTOR_, mapThreshold_, mapSize_,
+                        orderedList_ != null
+                                ? Arrays.toString(Arrays.copyOf(orderedList_, Math.min(orderedList_.length, maxLen)))
+                                : null,
+                                orderedListSize_);
+    }
+
+    /**
+     * Helper for identifying if we need to position our new entry differently.
+     */
+    private enum Position {
+        NONE, FIRST, LAST
+    }
+
+    /**
+     * Well, we need that to satisfy the map implementation concept.
+     *
+     * @param <K> the key
+     * @param <V> the value
+     */
+    static class Entry<K, V> implements Map.Entry<K, V> {
+        private final K key_;
+        private final V value_;
+
+        Entry(final K key, final V value) {
+            this.key_ = key;
+            this.value_ = value;
+        }
+
+        @Override
+        public K getKey() {
+            return key_;
+        }
+
+        @Override
+        public V getValue() {
+            return value_;
+        }
+
+        @Override
+        public V setValue(final V value) {
+            throw new UnsupportedOperationException("This map does not support write-through via an entry");
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(key_) ^ Objects.hashCode(value_);
+        }
+
+        @Override
+        public String toString() {
+            return key_ + "=" + value_;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (o == this) {
+                return true;
+            }
+
+            if (o instanceof Map.Entry) {
+                final Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+
+                if (Objects.equals(key_, e.getKey()) && Objects.equals(value_, e.getValue())) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/src/main/java/org/htmlunit/util/OrderedFastHashMap.java
+++ b/src/main/java/org/htmlunit/util/OrderedFastHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ * Copyright (c) 2002-2024 Gargoyle Software Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  */
 package org.htmlunit.util;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,7 +55,7 @@ import java.util.Set;
  *
  * @author Ren&eacute; Schwietzke
  */
-public class OrderedFastHashMap<K, V> implements Map<K, V> {
+public class OrderedFastHashMap<K, V> implements Map<K, V>, Serializable {
     // our placeholders in the map
     private static Object FREE_KEY_ = null;
     private static Object REMOVED_KEY_ = new Object();

--- a/src/main/java/org/htmlunit/util/StringUtils.java
+++ b/src/main/java/org/htmlunit/util/StringUtils.java
@@ -15,9 +15,9 @@
 package org.htmlunit.util;
 
 import java.nio.charset.Charset;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,8 +49,8 @@ public final class StringUtils {
                                 + "\\s*((0|[1-9]\\d?|100)(.\\d*)?)%\\s*\\)");
     private static final Pattern ILLEGAL_FILE_NAME_CHARS = Pattern.compile("\\\\|/|\\||:|\\?|\\*|\"|<|>|\\p{Cntrl}");
 
-    private static final Map<String, String> CamelizeCache_ = new HashMap<>();
-    private static final Map<String, String> RootLowercaseCache_ = new HashMap<>();
+    private static final Map<String, String> CamelizeCache_ = new ConcurrentHashMap<>();
+    private static final Map<String, String> RootLowercaseCache_ = new ConcurrentHashMap<>();
 
     /**
      * Disallow instantiation of this class.

--- a/src/main/java/org/htmlunit/util/StringUtils.java
+++ b/src/main/java/org/htmlunit/util/StringUtils.java
@@ -348,20 +348,15 @@ public final class StringUtils {
         return result;
     }
 
-    public static String toRootLowerCaseWithCache(final String string) {
-        if (string == null) {
-            return null;
-        }
-
-        String result = RootLowercaseCache_.get(string);
-        if (null != result) {
-            return result;
-        }
-
-        result = string.toLowerCase(Locale.ROOT);
-        RootLowercaseCache_.put(string, result);
-
-        return result;
+    /**
+     * Lowercases a string by checking and check for null first. There
+     * is no cache involved and the ROOT locale is used to convert it.
+     *
+     * @param s the string to lowercase
+     * @return the lowercased string
+     */
+    public static String toRootLowerCase(final String s) {
+        return s == null ? null : s.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/org/htmlunit/util/XmlUtils.java
+++ b/src/main/java/org/htmlunit/util/XmlUtils.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -274,7 +273,7 @@ public final class XmlUtils {
                             namedNodeMapToSaxAttributes(nodeAttributes, attributesOrderMap, source));
         }
 
-        final Map<String, DomAttr> attributes = new LinkedHashMap<>();
+        final OrderedFastHashMap<String, DomAttr> attributes = new OrderedFastHashMap<>();
         for (int i = 0; i < nodeAttributes.getLength(); i++) {
             final int orderedIndex = Platform.getIndex(nodeAttributes, attributesOrderMap, source, i);
             final Attr attribute = (Attr) nodeAttributes.item(orderedIndex);

--- a/src/test/java/org/htmlunit/util/OrderedFastHashMapTest.java
+++ b/src/test/java/org/htmlunit/util/OrderedFastHashMapTest.java
@@ -1242,6 +1242,37 @@ public class OrderedFastHashMapTest {
     }
 
     /**
+     * Try to test early growth and potential problems when growing. Based on
+     * infinite loop observations.
+     */
+    @Test
+    public void growFromSmall_InfiniteLoopIsssue() {
+        for (int initSize = 0; initSize < 100; initSize++) {
+//            System.out.println("Initial Size: " + initSize);
+            final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(initSize);
+
+            for (int i = 0; i < 300; i++) {
+//                System.out.println(" Iteration: " + i);
+
+                // add one
+                m.put(i, i);
+
+                // ask for all
+                for (int j = 0; j <= i; j++) {
+//                    System.out.println("  Get: " + j);
+                    assertEquals(Integer.valueOf(j), m.get(j));
+                }
+
+                // ask for something else
+                for (int j = -1; j >= -100; j--) {
+//                    System.out.println("  Get Null: " + j);
+                    assertNull(m.get(j));
+                }
+            }
+        }
+    }
+
+    /**
      * Try to hit all slots with bad hashcodes
      */
     @Test

--- a/src/test/java/org/htmlunit/util/OrderedFastHashMapTest.java
+++ b/src/test/java/org/htmlunit/util/OrderedFastHashMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ * Copyright (c) 2002-2024 Gargoyle Software Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-@SuppressWarnings("checkstyle:AvoidNestedBlocks")
 public class OrderedFastHashMapTest {
+
     @Test
     public void ctr() {
         final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
@@ -218,38 +218,34 @@ public class OrderedFastHashMapTest {
         f.put("dd", 4);
         f.put("ee", 5);
 
-        {
-            final List<String> k = f.keys();
-            assertEquals(5, k.size());
-            assertTrue(k.contains("aa"));
-            assertTrue(k.contains("bb"));
-            assertTrue(k.contains("cc"));
-            assertTrue(k.contains("dd"));
-            assertTrue(k.contains("ee"));
-        }
+        final List<String> k = f.keys();
+        assertEquals(5, k.size());
+        assertTrue(k.contains("aa"));
+        assertTrue(k.contains("bb"));
+        assertTrue(k.contains("cc"));
+        assertTrue(k.contains("dd"));
+        assertTrue(k.contains("ee"));
 
+        // remove from the middle
         assertEquals(Integer.valueOf(3), f.remove("cc"));
         f.remove("c");
-        {
-            final List<String> k = f.keys();
-            assertEquals(4, k.size());
-            assertTrue(k.contains("aa"));
-            assertTrue(k.contains("bb"));
-            assertTrue(k.contains("dd"));
-            assertTrue(k.contains("ee"));
-        }
+        final List<String> k2 = f.keys();
+        assertEquals(4, k2.size());
+        assertTrue(k2.contains("aa"));
+        assertTrue(k2.contains("bb"));
+        assertTrue(k2.contains("dd"));
+        assertTrue(k2.contains("ee"));
 
+        // add to the end, remove unknown
         f.put("zz", 10);
         f.remove("c");
-        {
-            final List<String> k = f.keys();
-            assertEquals(5, k.size());
-            assertTrue(k.contains("aa"));
-            assertTrue(k.contains("bb"));
-            assertTrue(k.contains("dd"));
-            assertTrue(k.contains("ee"));
-            assertTrue(k.contains("zz"));
-        }
+        final List<String> k3 = f.keys();
+        assertEquals(5, k3.size());
+        assertTrue(k3.contains("aa"));
+        assertTrue(k3.contains("bb"));
+        assertTrue(k3.contains("dd"));
+        assertTrue(k3.contains("ee"));
+        assertTrue(k3.contains("zz"));
 
         // ask for something unknown
         assertNull(f.get("unknown"));
@@ -264,69 +260,69 @@ public class OrderedFastHashMapTest {
         f.put("dd", 4);
         f.put("ee", 5);
 
-        {
-            final List<Integer> values = f.values();
-            assertEquals(5, values.size());
-            assertTrue(values.contains(1));
-            assertTrue(values.contains(2));
-            assertTrue(values.contains(3));
-            assertTrue(values.contains(4));
-            assertTrue(values.contains(5));
-        }
+        // initial values
+        final List<Integer> values = f.values();
+        assertEquals(5, values.size());
+        assertTrue(values.contains(1));
+        assertTrue(values.contains(2));
+        assertTrue(values.contains(3));
+        assertTrue(values.contains(4));
+        assertTrue(values.contains(5));
 
+        // something removed
         assertEquals(Integer.valueOf(3), f.remove("cc"));
+        // something unknnown removed
         f.remove("c");
-        {
-            final List<Integer> values = f.values();
-            assertEquals(4, values.size());
-            assertTrue(values.contains(1));
-            assertTrue(values.contains(2));
-            assertTrue(values.contains(4));
-            assertTrue(values.contains(5));
-        }
+        final List<Integer> v2 = f.values();
+        assertEquals(4, v2.size());
+        assertTrue(v2.contains(1));
+        assertTrue(v2.contains(2));
+        assertTrue(v2.contains(4));
+        assertTrue(v2.contains(5));
     }
 
     @Test
-    public void remove_simple() {
-        {
-            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
-            // remove instantly
-            m1.put("b", "value");
-            assertEquals("value", m1.remove("b"));
-            assertEquals(0, m1.size());
-        }
+    public void remove_simple_only_one() {
+        final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+        // remove instantly
+        m1.put("b", "value");
+        assertEquals("value", m1.remove("b"));
+        assertEquals(0, m1.size());
+    }
 
-        // remove the one before
-        {
-            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
-            m1.put("b", "bvalue");
-            m1.put("c", "cvalue");
-            assertEquals("bvalue", m1.remove("b"));
-            assertEquals("cvalue", m1.get("c"));
-            assertEquals(1, m1.size());
-        }
+    @Test
+    public void remove_simple_first() {
+        // remove first
+        final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+        m1.put("b", "bvalue");
+        m1.put("c", "cvalue");
+        assertEquals("bvalue", m1.remove("b"));
+        assertEquals("cvalue", m1.get("c"));
+        assertEquals(1, m1.size());
+    }
 
+    @Test
+    public void remove_simple_from_the_middle() {
         // remove the one in the middle
-        {
-            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
-            m1.put("a", "avalue");
-            m1.put("b", "bvalue");
-            m1.put("c", "cvalue");
-            assertEquals("bvalue", m1.remove("b"));
-            assertEquals("avalue", m1.get("a"));
-            assertEquals("cvalue", m1.get("c"));
-            assertEquals(2, m1.size());
-            assertEquals("a", m1.getKey(0));
-            assertEquals("c", m1.getKey(1));
-        }
+        final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+        m1.put("a", "avalue");
+        m1.put("b", "bvalue");
+        m1.put("c", "cvalue");
+        assertEquals("bvalue", m1.remove("b"));
+        assertEquals("avalue", m1.get("a"));
+        assertEquals("cvalue", m1.get("c"));
+        assertEquals(2, m1.size());
+        assertEquals("a", m1.getKey(0));
+        assertEquals("c", m1.getKey(1));
+    }
 
+    @Test
+    public void remove_simple_unknown() {
         // remove unknown
-        {
-            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
-            assertNull(m1.remove("a"));
-            m1.put("b", "value");
-            assertNull(m1.remove("a"));
-        }
+        final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+        assertNull(m1.remove("a"));
+        m1.put("b", "value");
+        assertNull(m1.remove("a"));
     }
 
     @Test
@@ -456,51 +452,55 @@ public class OrderedFastHashMapTest {
     }
 
     @Test
-    public void removeByIndex() {
-        {
-            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
-            m.put("a", 1);
-            m.put("b", 2);
-            m.put("c", 3);
-            m.remove(0);
+    public void removeByIndex_first() {
+        final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+        m.put("a", 1);
+        m.put("b", 2);
+        m.put("c", 3);
+        m.remove(0);
 
-            assertEquals("b", m.getKey(0));
-            assertEquals("c", m.getKey(1));
-            assertEquals(2, m.size());
-        }
-        {
-            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
-            m.put("a", 1);
-            m.put("b", 2);
-            m.put("c", 3);
-            m.remove(1);
+        assertEquals("b", m.getKey(0));
+        assertEquals("c", m.getKey(1));
+        assertEquals(2, m.size());
+    }
 
-            assertEquals("a", m.getKey(0));
-            assertEquals("c", m.getKey(1));
-            assertEquals(2, m.size());
-        }
-        {
-            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
-            m.put("a", 1);
-            m.put("b", 2);
-            m.put("c", 3);
-            m.remove(2);
+    @Test
+    public void removeByIndex_second() {
+        final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+        m.put("a", 1);
+        m.put("b", 2);
+        m.put("c", 3);
+        m.remove(1);
 
-            assertEquals("a", m.getKey(0));
-            assertEquals("b", m.getKey(1));
-            assertEquals(2, m.size());
-        }
-        {
-            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
-            m.put("a", 1);
-            m.put("b", 2);
-            m.put("c", 3);
-            m.remove(1);
-            m.remove(1);
-            m.remove(0);
+        assertEquals("a", m.getKey(0));
+        assertEquals("c", m.getKey(1));
+        assertEquals(2, m.size());
+    }
 
-            assertEquals(0, m.size());
-        }
+    @Test
+    public void removeByIndex_last() {
+        final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+        m.put("a", 1);
+        m.put("b", 2);
+        m.put("c", 3);
+        m.remove(2);
+
+        assertEquals("a", m.getKey(0));
+        assertEquals("b", m.getKey(1));
+        assertEquals(2, m.size());
+    }
+
+    @Test
+    public void removeByIndex_middle_to_empty() {
+        final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+        m.put("a", 1);
+        m.put("b", 2);
+        m.put("c", 3);
+        m.remove(1);
+        m.remove(1);
+        m.remove(0);
+
+        assertEquals(0, m.size());
     }
 
     @Test
@@ -556,7 +556,7 @@ public class OrderedFastHashMapTest {
         }
         assertEquals(3 * 1972, m.size());
 
-        BiConsumer<String, Integer> t = (k, index) -> {
+        final BiConsumer<String, Integer> t = (k, index) -> {
             assertEquals("V" + k, m.get(k));
             assertEquals(k, m.getKey(index));
             assertEquals("V" + k, m.getValue(index));
@@ -625,7 +625,7 @@ public class OrderedFastHashMapTest {
             }
 
             // add these all and remove first
-            for (String k : keys) {
+            for (final String k : keys) {
                 m.put(k, "V" + k);
             }
             // remove first
@@ -647,65 +647,70 @@ public class OrderedFastHashMapTest {
     }
 
     @Test
-    public void addFirst() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.addFirst("a", "1");
-            assertEquals(1, m.size());
-            assertEquals("a", m.getKey(0));
-            assertEquals("1", m.getValue(0));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.addFirst("a", "1");
-            m.addFirst("b", "2");
-            assertEquals(2, m.size());
-            assertEquals("a", m.getKey(1));
-            assertEquals("1", m.getValue(1));
-            assertEquals("b", m.getKey(0));
-            assertEquals("2", m.getValue(0));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.add("a", "1");
-            m.addFirst("b", "2");
-            assertEquals(2, m.size());
-            assertEquals("a", m.getKey(1));
-            assertEquals("1", m.getValue(1));
-            assertEquals("b", m.getKey(0));
-            assertEquals("2", m.getValue(0));
-        }
+    public void addFirst_to_empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.addFirst("a", "1");
+        assertEquals(1, m.size());
+        assertEquals("a", m.getKey(0));
+        assertEquals("1", m.getValue(0));
+    }
+
+
+    @Test
+    public void addFirst_twice() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.addFirst("a", "1");
+        m.addFirst("b", "2");
+        assertEquals(2, m.size());
+        assertEquals("a", m.getKey(1));
+        assertEquals("1", m.getValue(1));
+        assertEquals("b", m.getKey(0));
+        assertEquals("2", m.getValue(0));
     }
 
     @Test
-    public void addLast() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.addLast("a", "1");
-            assertEquals(1, m.size());
-            assertEquals("a", m.getKey(0));
-            assertEquals("1", m.getValue(0));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.addLast("a", "1");
-            m.addLast("b", "2");
-            assertEquals(2, m.size());
-            assertEquals("a", m.getKey(0));
-            assertEquals("1", m.getValue(0));
-            assertEquals("b", m.getKey(1));
-            assertEquals("2", m.getValue(1));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.add("a", "1");
-            m.addLast("b", "2");
-            assertEquals(2, m.size());
-            assertEquals("a", m.getKey(0));
-            assertEquals("1", m.getValue(0));
-            assertEquals("b", m.getKey(1));
-            assertEquals("2", m.getValue(1));
-        }
+    public void addFirst__second_to_normal_added() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.add("a", "1");
+        m.addFirst("b", "2");
+        assertEquals(2, m.size());
+        assertEquals("a", m.getKey(1));
+        assertEquals("1", m.getValue(1));
+        assertEquals("b", m.getKey(0));
+        assertEquals("2", m.getValue(0));
+    }
+
+    @Test
+    public void addLast_to_empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.addLast("a", "1");
+        assertEquals(1, m.size());
+        assertEquals("a", m.getKey(0));
+        assertEquals("1", m.getValue(0));
+    }
+
+    @Test
+    public void addLast_twice() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.addLast("a", "1");
+        m.addLast("b", "2");
+        assertEquals(2, m.size());
+        assertEquals("a", m.getKey(0));
+        assertEquals("1", m.getValue(0));
+        assertEquals("b", m.getKey(1));
+        assertEquals("2", m.getValue(1));
+    }
+
+    @Test
+    public void addLast_to_normally_added() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.add("a", "1");
+        m.addLast("b", "2");
+        assertEquals(2, m.size());
+        assertEquals("a", m.getKey(0));
+        assertEquals("1", m.getValue(0));
+        assertEquals("b", m.getKey(1));
+        assertEquals("2", m.getValue(1));
     }
 
     @Test
@@ -715,59 +720,65 @@ public class OrderedFastHashMapTest {
     }
 
     @Test
-    public void containsKey_True() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey", "any");
-            assertTrue(m.containsKey("akey"));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey1", "any");
-            m.put("akey2", "any");
-            m.put("akey3", "any");
-            m.put("akey4", "any");
-            assertTrue(m.containsKey("akey2"));
-            assertTrue(m.containsKey(new String("akey2")));
-        }
-        {
-            // same hash and same content
-            final OrderedFastHashMap<MockKey<String>, String> m = new OrderedFastHashMap<>();
-            final MockKey<String> mockKey1 = new MockKey<>(10, "akey1");
-            m.put(mockKey1, "any1");
-            m.put(new MockKey<String>(10, "akey2"), "any2");
-            m.put(new MockKey<String>(10, "akey3"), "any3");
-            m.put(new MockKey<String>(10, "akey4"), "any4");
-            assertTrue(m.containsKey(mockKey1));
-            assertTrue(m.containsKey(new MockKey<>(10, "akey1")));
-        }
+    public void containsKey_True_single() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey", "any");
+        assertTrue(m.containsKey("akey"));
     }
 
     @Test
-    public void containsKey_False() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey", "any");
-            assertFalse(m.containsKey("akey1"));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey1", "any");
-            m.put("akey2", "any");
-            m.put("akey3", "any");
-            assertFalse(m.containsKey("akey"));
-        }
-        {
-            // same hash but different content and same content different hash
-            final OrderedFastHashMap<MockKey<String>, String> m = new OrderedFastHashMap<>();
-            m.put(new MockKey<String>(10, "akey2"), "any2");
-            m.put(new MockKey<String>(10, "akey3"), "any3");
-            m.put(new MockKey<String>(10, "akey4"), "any4");
-            assertFalse(m.containsKey(new MockKey<>(10, "akey")));
-            assertFalse(m.containsKey(new MockKey<>(114, "akey2")));
-            assertFalse(m.containsKey(new MockKey<>(113, "akey3")));
-            assertFalse(m.containsKey(new MockKey<>(112, "akey4")));
-        }
+    public void containsKey_True_many() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey1", "any");
+        m.put("akey2", "any");
+        m.put("akey3", "any");
+        m.put("akey4", "any");
+        assertTrue(m.containsKey("akey2"));
+        assertTrue(m.containsKey(new String("akey2")));
+    }
+
+    @Test
+    public void containsKey_True_content_based() {
+        // same hash and different content
+        final OrderedFastHashMap<MockKey<String>, String> m = new OrderedFastHashMap<>();
+        final MockKey<String> mockKey1 = new MockKey<>(10, "akey1");
+        m.put(mockKey1, "any1");
+        m.put(new MockKey<String>(10, "akey2"), "any2");
+        m.put(new MockKey<String>(10, "akey3"), "any3");
+        m.put(new MockKey<String>(10, "akey4"), "any4");
+        assertTrue(m.containsKey(mockKey1));
+        assertTrue(m.containsKey(new MockKey<>(10, "akey1")));
+    }
+
+    @Test
+    public void containsKey_False_single() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey", "any");
+        assertFalse(m.containsKey("akey1"));
+    }
+
+    @Test
+    public void containsKey_False_many() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey1", "any");
+        m.put("akey2", "any");
+        m.put("akey3", "any");
+        assertFalse(m.containsKey("akey"));
+    }
+
+    @Test
+    public void containsKey_False_content_based() {
+        // same hash but different content
+        final OrderedFastHashMap<MockKey<String>, String> m = new OrderedFastHashMap<>();
+        m.put(new MockKey<String>(10, "akey2"), "any2");
+        m.put(new MockKey<String>(10, "akey3"), "any3");
+        m.put(new MockKey<String>(10, "akey4"), "any4");
+        assertFalse(m.containsKey(new MockKey<>(10, "akey")));
+
+        // different hash, same content
+        assertFalse(m.containsKey(new MockKey<>(114, "akey2")));
+        assertFalse(m.containsKey(new MockKey<>(113, "akey3")));
+        assertFalse(m.containsKey(new MockKey<>(112, "akey4")));
     }
 
     @Test
@@ -777,55 +788,75 @@ public class OrderedFastHashMapTest {
     }
 
     @Test
-    public void containsValue_True() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey3", "any");
-            assertTrue(m.containsValue("any"));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey1", "any1");
-            m.put("akey2", "any2");
-            m.put("akey3", "any3");
-            assertTrue(m.containsValue("any1"));
-            assertTrue(m.containsValue("any2"));
-            assertTrue(m.containsValue("any3"));
-            assertTrue(m.containsValue(new String("any1")));
-            assertTrue(m.containsValue(new String("any2")));
-            assertTrue(m.containsValue(new String("any3")));
-        }
+    public void containsValue_True_single() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey3", "any");
+        assertTrue(m.containsValue("any"));
     }
 
     @Test
-    public void containsValue_False() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey3", "any");
-            assertFalse(m.containsValue("asdf"));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("akey1", "any1");
-            m.put("akey2", "any2");
-            m.put("akey3", "any3");
-            assertFalse(m.containsValue("akey1"));
-            assertFalse(m.containsValue("akey2"));
-            assertFalse(m.containsValue("akey3"));
-        }
+    public void containsValue_True_content_based() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey1", "any1");
+        m.put("akey2", "any2");
+        m.put("akey3", "any3");
+        assertTrue(m.containsValue("any1"));
+        assertTrue(m.containsValue("any2"));
+        assertTrue(m.containsValue("any3"));
+        assertTrue(m.containsValue(new String("any1")));
+        assertTrue(m.containsValue(new String("any2")));
+        assertTrue(m.containsValue(new String("any3")));
     }
 
     @Test
-    public void isEmpty() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            assertTrue(m.isEmpty());
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("aaa", "a");
-            assertFalse(m.isEmpty());
-        }
+    public void containsValue_False_single() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey3", "any");
+        assertFalse(m.containsValue("asdf"));
+    }
+
+    @Test
+    public void containsValue_False_many() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("akey1", "any1");
+        m.put("akey2", "any2");
+        m.put("akey3", "any3");
+        // not mistaking the key as value
+        assertFalse(m.containsValue("akey1"));
+        assertFalse(m.containsValue("akey2"));
+        assertFalse(m.containsValue("akey3"));
+
+        // just some other values
+        assertFalse(m.containsValue("any5"));
+        assertFalse(m.containsValue("any6"));
+        assertFalse(m.containsValue("any7"));
+    }
+
+    @Test
+    public void isEmpty_empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        assertTrue(m.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_size_zero() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(0);
+        assertTrue(m.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_false() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("aaa", "a");
+        assertFalse(m.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_after_clear() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("aaa", "a");
+        m.clear();
+        assertTrue(m.isEmpty());
     }
 
     @Test
@@ -866,332 +897,383 @@ public class OrderedFastHashMapTest {
     }
 
     @Test
+    public void entrySet_empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        final Set<Entry<String, String>> set = m.entrySet();
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void entrySet_zero_size() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(0);
+        final Set<Entry<String, String>> set = m.entrySet();
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
     public void entrySet() {
-        {
-            OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            final Set<Entry<String, String>> set = m.entrySet();
-            assertEquals(0, set.size());
-            assertTrue(set.isEmpty());
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("K1", "V1");
-            final Set<Entry<String, String>> set = m.entrySet();
-            assertEquals(1, set.size());
-            assertFalse(set.isEmpty());
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+        final Set<Entry<String, String>> set = m.entrySet();
+        assertEquals(1, set.size());
+        assertFalse(set.isEmpty());
 
-            final Entry<String, String> e1 = set.iterator().next();
-            assertEquals("K1", e1.getKey());
-            assertEquals("V1", e1.getValue());
+        final Entry<String, String> e1 = set.iterator().next();
+        assertEquals("K1", e1.getKey());
+        assertEquals("V1", e1.getValue());
 
-            final Map<String, String> map = new LinkedHashMap<>();
-            map.put("K1", "V1");
-            map.put("K2", "V1");
-            Iterator<Map.Entry<String, String>> i = map.entrySet().iterator();
-            final Entry<String, String> e2 = i.next();
-            final Entry<String, String> e3 = i.next();
+        final Map<String, String> map = new OrderedFastHashMap<>();
+        map.put("K1", "V1");
+        map.put("K2", "V1");
+        final Iterator<Map.Entry<String, String>> i = map.entrySet().iterator();
+        final Entry<String, String> e2 = i.next();
+        final Entry<String, String> e3 = i.next();
 
-            assertTrue(set.contains(e1));
-            assertTrue(set.contains(e2));
+        assertTrue(set.contains(e1));
+        assertTrue(set.contains(e2));
 
-            assertFalse(set.contains("a"));
-            assertFalse(set.contains(e3));
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            IntStream.rangeClosed(0, 11).forEach(i -> m.put("K" + i, "V" + i));
-            final Set<Entry<String, String>> set = m.entrySet();
-            assertEquals(12, set.size());
-            assertFalse(set.isEmpty());
-
-            final Iterator<Entry<String, String>> iter = set.iterator();
-            IntStream.rangeClosed(0, 11).forEach(i -> {
-                assertTrue(iter.hasNext());
-                final Entry<String, String> e = iter.next();
-                assertEquals("K" + i, e.getKey());
-                assertEquals("V" + i, e.getValue());
-            });
-            assertFalse(iter.hasNext());
-
-            // overread
-            assertThrows(NoSuchElementException.class, () -> iter.next());
-        }
+        assertFalse(set.contains("a"));
+        assertFalse(set.contains(e3));
     }
 
     @Test
-    public void entrySet_toArray() {
-        {
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            final Set<Entry<String, String>> set = m.entrySet();
-            assertEquals(0, set.toArray().length);
-            assertEquals(0, set.toArray(new Map.Entry[0]).length);
-            assertEquals(10, set.toArray(new String[10]).length);
+    public void entrySet_large() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        IntStream.rangeClosed(0, 11).forEach(i -> m.put("K" + i, "V" + i));
+        final Set<Entry<String, String>> set = m.entrySet();
+        assertEquals(12, set.size());
+        assertFalse(set.isEmpty());
 
-            // unfilled despite length 10
-            final String[] a = set.toArray(new String[10]);
-            for (int i = 0; i < 10; i++) {
-                assertNull(a[i]);
-            }
-        }
-        {
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            m.put("K1", "V1");
-            final Set<Entry<String, String>> set = m.entrySet();
-            assertEquals(1, set.toArray().length);
-            assertEquals(1, set.toArray(new Map.Entry[0]).length);
-            assertEquals(1, set.toArray(new Map.Entry[1]).length);
-
-            assertNotNull(set.toArray()[0]);
-            assertEquals("K1", ((Map.Entry<String, String>) set.toArray()[0]).getKey());
-            assertEquals("V1", ((Map.Entry<String, String>) set.toArray()[0]).getValue());
-
-            assertEquals("K1", set.toArray(new Map.Entry[0])[0].getKey());
-            assertEquals("V1", set.toArray(new Map.Entry[0])[0].getValue());
-
-            assertEquals("K1", set.toArray(new Map.Entry[1])[0].getKey());
-            assertEquals("V1", set.toArray(new Map.Entry[1])[0].getValue());
-        }
-        {
-            // ensure we get our array back when it is sufficiently sized
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            m.put("K1", "V1");
-            final Set<Entry<String, String>> set = m.entrySet();
-
-            // right sized
-            final Map.Entry[] array1 = new Map.Entry[1];
-            assertSame(array1, set.toArray(array1));
-
-            // oversized
-            final Map.Entry[] array2 = new Map.Entry[10];
-            assertSame(array2, set.toArray(array2));
-        }
-        {
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
-            final Object[] a1 = m.entrySet().toArray();
-            final Map.Entry[] a2 = m.entrySet().toArray(new Map.Entry[45]);
-            assertEquals(45, a1.length);
-            assertEquals(45, a2.length);
-
-            for (int i = 0; i <= 44; i++) {
-                assertEquals("K" + i, ((Map.Entry<String, String>) a1[i]).getKey());
-                assertEquals("V" + i, ((Map.Entry<String, String>) a1[i]).getValue());
-
-                assertEquals("K" + i, a2[i].getKey());
-                assertEquals("V" + i, a2[i].getValue());
-            }
-            ;
-        }
-    }
-
-    @Test
-    public void keySet() {
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            final Set<String> set = m.keySet();
-            assertEquals(0, set.size());
-            assertTrue(set.isEmpty());
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("K1", "V1");
-            final Set<String> set = m.keySet();
-            assertEquals(1, set.size());
-            assertFalse(set.isEmpty());
-
-            final String e1 = set.iterator().next();
-            assertEquals("K1", e1);
-        }
-        {
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
-            final Set<String> set = m.keySet();
-            assertEquals(45, set.size());
-            assertFalse(set.isEmpty());
-
-            final Iterator<String> iter = set.iterator();
-            IntStream.rangeClosed(0, 44).forEach(i -> {
-                assertTrue(iter.hasNext());
-                final String e = iter.next();
-                assertEquals("K" + i, e);
-                assertTrue(set.contains("K" + i));
-            });
-            assertFalse(iter.hasNext());
-
-            // overread
-            assertThrows(NoSuchElementException.class, () -> iter.next());
-        }
-    }
-
-    @Test
-    public void keySet_toArray() {
-        {
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            final Set<String> set = m.keySet();
-            assertEquals(0, set.toArray().length);
-            assertEquals(0, set.toArray(new String[0]).length);
-            assertEquals(10, set.toArray(new String[10]).length);
-
-            // unfilled despite length 10
-            String[] a = set.toArray(new String[10]);
-            for (int i = 0; i < 10; i++) {
-                assertNull(a[i]);
-            }
-        }
-        {
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            m.put("K1", "V1");
-            final Set<String> set = m.keySet();
-            assertEquals(1, set.toArray().length);
-            assertEquals(1, set.toArray(new String[0]).length);
-            assertEquals(1, set.toArray(new String[1]).length);
-
-            assertEquals("K1", set.toArray()[0]);
-            assertEquals("K1", set.toArray(new String[0])[0]);
-            assertEquals("K1", set.toArray(new String[1])[0]);
-        }
-        {
-            // ensure we get our array back when it is sufficiently sized
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            m.put("K1", "V1");
-            final Set<String> set = m.keySet();
-
-            // right sized
-            String[] array1 = new String[1];
-            assertSame(array1, set.toArray(array1));
-
-            // oversized
-            String[] array2 = new String[10];
-            assertSame(array2, set.toArray(array2));
-        }
-        {
-            final Map<String, String> m = new OrderedFastHashMap<>();
-            IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
-            final Object[] a1 = m.keySet().toArray();
-            final String[] a2 = m.keySet().toArray(new String[45]);
-            assertEquals(45, a1.length);
-            assertEquals(45, a2.length);
-
-            for (int i = 0; i <= 44; i++) {
-                assertEquals("K" + i, a1[i]);
-                assertEquals("K" + i, a2[i]);
-            }
-            ;
-        }
-    }
-
-    @Test
-    public void putAll() {
-        {
-            // we cannot add ourselves!
-            IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-                OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-                m.putAll(m);
-            });
-            assertEquals("Cannot add myself", thrown.getMessage());
-        }
-        {
-            // empty
-            final Map<String, String> src = new HashMap<>();
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.putAll(src);
-            assertEquals(0, m.size());
-        }
-        {
-            // target empty
-            final Map<String, String> src = new LinkedHashMap<>();
-            IntStream.rangeClosed(0, 10).forEach(i -> src.put("K" + i, "V" + i));
-
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.putAll(src);
-            assertEquals(11, m.size());
-
-            final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
-            IntStream.rangeClosed(0, 10).forEach(i -> {
-                assertTrue(iter.hasNext());
-                final Entry<String, String> e = iter.next();
-                assertEquals("K" + i, e.getKey());
-                assertEquals("V" + i, e.getValue());
-            });
-            assertFalse(iter.hasNext());
-        }
-        {
-            // src empty
-            final Map<String, String> src = new LinkedHashMap<>();
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("K1", "V1");
-
-            m.putAll(src);
-            assertEquals(1, m.size());
-
-            final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
+        final Iterator<Entry<String, String>> iter = set.iterator();
+        IntStream.rangeClosed(0, 11).forEach(i -> {
             assertTrue(iter.hasNext());
             final Entry<String, String> e = iter.next();
-            assertEquals("K1", e.getKey());
-            assertEquals("V1", e.getValue());
-            assertFalse(iter.hasNext());
+            assertEquals("K" + i, e.getKey());
+            assertEquals("V" + i, e.getValue());
+        });
+        assertFalse(iter.hasNext());
+
+        // overread
+        assertThrows(NoSuchElementException.class, () -> iter.next());
+    }
+
+    @Test
+    public void entrySet_toArray_empty() {
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        final Set<Entry<String, String>> set = m.entrySet();
+        assertEquals(0, set.toArray().length);
+        assertEquals(0, set.toArray(new Map.Entry[0]).length);
+        assertEquals(10, set.toArray(new String[10]).length);
+
+        // unfilled despite length 10
+        final String[] a = set.toArray(new String[10]);
+        for (int i = 0; i < 10; i++) {
+            assertNull(a[i]);
         }
-        {
-            // target not empty
-            final Map<String, String> src = new LinkedHashMap<>();
-            IntStream.rangeClosed(0, 17).forEach(i -> src.put("SRCK" + i, "SRCV" + i));
+    }
 
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            IntStream.rangeClosed(100, 111).forEach(i -> m.put("K" + i, "V" + i));
+    @Test
+    public void entrySet_toArray_zero_sized() {
+        final Map<String, String> m = new OrderedFastHashMap<>(0);
+        final Set<Entry<String, String>> set = m.entrySet();
+        assertEquals(0, set.toArray().length);
+        assertEquals(0, set.toArray(new Map.Entry[0]).length);
+        assertEquals(10, set.toArray(new String[10]).length);
 
-            m.putAll(src);
-            assertEquals(12 + 18, m.size());
+        // unfilled despite length 10
+        final String[] a = set.toArray(new String[10]);
+        for (int i = 0; i < 10; i++) {
+            assertNull(a[i]);
+        }
+    }
 
-            final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
-            IntStream.rangeClosed(100, 111).forEach(i -> {
-                assertTrue(iter.hasNext());
-                final Entry<String, String> e = iter.next();
-                assertEquals("K" + i, e.getKey());
-                assertEquals("V" + i, e.getValue());
-            });
+    @Test
+    public void entrySet_toArray_normal() {
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+        final Set<Entry<String, String>> set = m.entrySet();
+        assertEquals(1, set.toArray().length);
+        assertEquals(1, set.toArray(new Map.Entry[0]).length);
+        assertEquals(1, set.toArray(new Map.Entry[1]).length);
+
+        assertNotNull(set.toArray()[0]);
+        assertEquals("K1", ((Map.Entry<String, String>) set.toArray()[0]).getKey());
+        assertEquals("V1", ((Map.Entry<String, String>) set.toArray()[0]).getValue());
+
+        assertEquals("K1", set.toArray(new Map.Entry[0])[0].getKey());
+        assertEquals("V1", set.toArray(new Map.Entry[0])[0].getValue());
+
+        assertEquals("K1", set.toArray(new Map.Entry[1])[0].getKey());
+        assertEquals("V1", set.toArray(new Map.Entry[1])[0].getValue());
+    }
+
+    @Test
+    public void entrySet_toArray_get_same_back() {
+        // ensure we get our array back when it is sufficiently sized
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+        final Set<Entry<String, String>> set = m.entrySet();
+
+        // right sized
+        final Map.Entry[] array1 = new Map.Entry[1];
+        assertSame(array1, set.toArray(array1));
+
+        // oversized
+        final Map.Entry[] array2 = new Map.Entry[10];
+        assertSame(array2, set.toArray(array2));
+    }
+
+    @Test
+    public void entrySet_toArray_large() {
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
+        final Object[] a1 = m.entrySet().toArray();
+        final Map.Entry[] a2 = m.entrySet().toArray(new Map.Entry[45]);
+        assertEquals(45, a1.length);
+        assertEquals(45, a2.length);
+
+        for (int i = 0; i <= 44; i++) {
+            assertEquals("K" + i, ((Map.Entry<String, String>) a1[i]).getKey());
+            assertEquals("V" + i, ((Map.Entry<String, String>) a1[i]).getValue());
+
+            assertEquals("K" + i, a2[i].getKey());
+            assertEquals("V" + i, a2[i].getValue());
+        }
+    }
+
+    @Test
+    public void keySet_empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        final Set<String> set = m.keySet();
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void keySet_size_zero() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(0);
+        final Set<String> set = m.keySet();
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void keySet_one() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+        final Set<String> set = m.keySet();
+        assertEquals(1, set.size());
+        assertFalse(set.isEmpty());
+
+        final String e1 = set.iterator().next();
+        assertEquals("K1", e1);
+    }
+
+    @Test
+    public void keySet_large() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
+        final Set<String> set = m.keySet();
+        assertEquals(45, set.size());
+        assertFalse(set.isEmpty());
+
+        final Iterator<String> iter = set.iterator();
+        IntStream.rangeClosed(0, 44).forEach(i -> {
             assertTrue(iter.hasNext());
-            IntStream.rangeClosed(0, 17).forEach(i -> {
-                assertTrue(iter.hasNext());
-                final Entry<String, String> e = iter.next();
-                assertEquals("SRCK" + i, e.getKey());
-                assertEquals("SRCV" + i, e.getValue());
-            });
-            assertFalse(iter.hasNext());
-        }
-        {
-            // same type but not same map
-            final OrderedFastHashMap<String, String> src = new OrderedFastHashMap<>();
-            IntStream.rangeClosed(19, 99).forEach(i -> src.put("K" + i, "V" + i));
+            final String e = iter.next();
+            assertEquals("K" + i, e);
+            assertTrue(set.contains("K" + i));
+        });
+        assertFalse(iter.hasNext());
 
+        // overread
+        assertThrows(NoSuchElementException.class, () -> iter.next());
+    }
+
+    @Test
+    public void keySet_toArray_empty() {
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        final Set<String> set = m.keySet();
+        assertEquals(0, set.toArray().length);
+        assertEquals(0, set.toArray(new String[0]).length);
+        assertEquals(10, set.toArray(new String[10]).length);
+
+        // unfilled despite length 10
+        final String[] a = set.toArray(new String[10]);
+        for (int i = 0; i < 10; i++) {
+            assertNull(a[i]);
+        }
+    }
+
+    @Test
+    public void keySet_toArray_one() {
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+        final Set<String> set = m.keySet();
+        assertEquals(1, set.toArray().length);
+        assertEquals(1, set.toArray(new String[0]).length);
+        assertEquals(1, set.toArray(new String[1]).length);
+
+        assertEquals("K1", set.toArray()[0]);
+        assertEquals("K1", set.toArray(new String[0])[0]);
+        assertEquals("K1", set.toArray(new String[1])[0]);
+    }
+
+    @Test
+    public void keySet_toArray_same_array() {
+        // ensure we get our array back when it is sufficiently sized
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+        final Set<String> set = m.keySet();
+
+        // right sized
+        final String[] array1 = new String[1];
+        assertSame(array1, set.toArray(array1));
+
+        // oversized
+        final String[] array2 = new String[10];
+        assertSame(array2, set.toArray(array2));
+    }
+
+    @Test
+    public void keySet_toArray_many() {
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
+        final Object[] a1 = m.keySet().toArray();
+        final String[] a2 = m.keySet().toArray(new String[45]);
+        assertEquals(45, a1.length);
+        assertEquals(45, a2.length);
+
+        for (int i = 0; i <= 44; i++) {
+            assertEquals("K" + i, a1[i]);
+            assertEquals("K" + i, a2[i]);
+        }
+    }
+
+    @Test
+    public void putAll_cannot_add_self() {
+        // we cannot add ourselves!
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
             final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            IntStream.rangeClosed(0, 18).forEach(i -> m.put("K" + i, "V" + i));
+            m.putAll(m);
+        });
+        assertEquals("Cannot add myself", thrown.getMessage());
+    }
 
-            m.putAll(src);
-            assertEquals(100, m.size());
+    @Test
+    public void putAll_empty() {
+        // empty
+        final Map<String, String> src = new HashMap<>();
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.putAll(src);
+        assertEquals(0, m.size());
+    }
 
-            final Set<Entry<String, String>> set = m.entrySet();
-            final Iterator<Entry<String, String>> iter = set.iterator();
-            IntStream.rangeClosed(0, 99).forEach(i -> {
-                assertTrue(iter.hasNext());
-                final Entry<String, String> e = iter.next();
-                assertEquals("K" + i, e.getKey());
-                assertEquals("K" + i, e.getKey());
-                assertEquals("V" + i, e.getValue());
-            });
-            assertFalse(iter.hasNext());
-        }
-        {
-            // I can be added to other Map.putAll
-            final Map<String, String> src = new OrderedFastHashMap<>();
-            final Map<String, String> m = new HashMap<>();
-            m.putAll(src);
-            assertEquals(0, m.size());
-        }
+    @Test
+    public void putAll_target_empty() {
+        // target empty
+        final Map<String, String> src = new LinkedHashMap<>();
+        IntStream.rangeClosed(0, 10).forEach(i -> src.put("K" + i, "V" + i));
+
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.putAll(src);
+        assertEquals(11, m.size());
+
+        final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
+        IntStream.rangeClosed(0, 10).forEach(i -> {
+            assertTrue(iter.hasNext());
+            final Entry<String, String> e = iter.next();
+            assertEquals("K" + i, e.getKey());
+            assertEquals("V" + i, e.getValue());
+        });
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void putAll_source_empty() {
+        // src empty
+        final Map<String, String> src = new LinkedHashMap<>();
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+
+        m.putAll(src);
+        assertEquals(1, m.size());
+
+        final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
+        assertTrue(iter.hasNext());
+        final Entry<String, String> e = iter.next();
+        assertEquals("K1", e.getKey());
+        assertEquals("V1", e.getValue());
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void putAll_target_not_empty() {
+        // target not empty
+        final Map<String, String> src = new LinkedHashMap<>();
+        IntStream.rangeClosed(0, 17).forEach(i -> src.put("SRCK" + i, "SRCV" + i));
+
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        IntStream.rangeClosed(100, 111).forEach(i -> m.put("K" + i, "V" + i));
+
+        m.putAll(src);
+        assertEquals(12 + 18, m.size());
+
+        final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
+        IntStream.rangeClosed(100, 111).forEach(i -> {
+            assertTrue(iter.hasNext());
+            final Entry<String, String> e = iter.next();
+            assertEquals("K" + i, e.getKey());
+            assertEquals("V" + i, e.getValue());
+        });
+        assertTrue(iter.hasNext());
+        IntStream.rangeClosed(0, 17).forEach(i -> {
+            assertTrue(iter.hasNext());
+            final Entry<String, String> e = iter.next();
+            assertEquals("SRCK" + i, e.getKey());
+            assertEquals("SRCV" + i, e.getValue());
+        });
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void putAll_same_type_not_same_object() {
+        // same type but not same map
+        final OrderedFastHashMap<String, String> src = new OrderedFastHashMap<>();
+        IntStream.rangeClosed(19, 99).forEach(i -> src.put("K" + i, "V" + i));
+
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        IntStream.rangeClosed(0, 18).forEach(i -> m.put("K" + i, "V" + i));
+
+        m.putAll(src);
+        assertEquals(100, m.size());
+
+        final Set<Entry<String, String>> set = m.entrySet();
+        final Iterator<Entry<String, String>> iter = set.iterator();
+        IntStream.rangeClosed(0, 99).forEach(i -> {
+            assertTrue(iter.hasNext());
+            final Entry<String, String> e = iter.next();
+            assertEquals("K" + i, e.getKey());
+            assertEquals("K" + i, e.getKey());
+            assertEquals("V" + i, e.getValue());
+        });
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void putAll_to_another_map() {
+        // I can be added to other Map.putAll
+        final Map<String, String> src = new OrderedFastHashMap<>();
+        final Map<String, String> m = new HashMap<>();
+        m.putAll(src);
+        assertEquals(0, m.size());
     }
 
     @Test
     public void collision() {
-        OrderedFastHashMap<MockKey<String>, String> f = new OrderedFastHashMap<MockKey<String>, String>(13);
+        final OrderedFastHashMap<MockKey<String>, String> f = new OrderedFastHashMap<MockKey<String>, String>(13);
         IntStream.range(0, 15).forEach(i -> {
             f.put(new MockKey<String>(12, "k" + i), "v" + i);
         });
@@ -1248,24 +1330,19 @@ public class OrderedFastHashMapTest {
     @Test
     public void growFromSmall_InfiniteLoopIsssue() {
         for (int initSize = 0; initSize < 100; initSize++) {
-//            System.out.println("Initial Size: " + initSize);
             final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(initSize);
 
             for (int i = 0; i < 300; i++) {
-//                System.out.println(" Iteration: " + i);
-
                 // add one
                 m.put(i, i);
 
                 // ask for all
                 for (int j = 0; j <= i; j++) {
-//                    System.out.println("  Get: " + j);
                     assertEquals(Integer.valueOf(j), m.get(j));
                 }
 
                 // ask for something else
                 for (int j = -1; j >= -100; j--) {
-//                    System.out.println("  Get Null: " + j);
                     assertNull(m.get(j));
                 }
             }
@@ -1273,7 +1350,7 @@ public class OrderedFastHashMapTest {
     }
 
     /**
-     * Try to hit all slots with bad hashcodes
+     * Try to hit all slots with bad hashcodes.
      */
     @Test
     public void hitEachSlot() {
@@ -1325,72 +1402,84 @@ public class OrderedFastHashMapTest {
     }
 
     @Test
-    public void reverse() {
-        {
-            // can reverse empty without exception
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.reverse();
-        }
-        {
-            // can reverse 0 sized map
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(0);
-            m.reverse();
-        }
-        {
-            // reverse one entry map
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("k0", "v0");
-            m.reverse();
-            assertEquals("k0", m.getEntry(0).getKey());
-            assertEquals("v0", m.getEntry(0).getValue());
-        }
-        {
-            // reverse two entries map
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("k0", "v0");
-            m.put("k1", "v1");
-            m.reverse();
-            assertEquals("k1", m.getEntry(0).getKey());
-            assertEquals("v1", m.getEntry(0).getValue());
-            assertEquals("k0", m.getEntry(1).getKey());
-            assertEquals("v0", m.getEntry(1).getValue());
-        }
-        {
-            // reverse three entries map
-            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
-            m.put("k0", "v0");
-            m.put("k1", "v1");
-            m.put("k2", "v2");
-            m.reverse();
-            assertEquals("k2", m.getEntry(0).getKey());
-            assertEquals("v2", m.getEntry(0).getValue());
-            assertEquals("k1", m.getEntry(1).getKey());
-            assertEquals("v1", m.getEntry(1).getValue());
-            assertEquals("k0", m.getEntry(2).getKey());
-            assertEquals("v0", m.getEntry(2).getValue());
-        }
-        {
-            // many entries, odd
-            final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(15);
-            IntStream.range(0, 117).mapToObj(Integer::valueOf).forEach(i -> m.put(i, i));
-            m.reverse();
-            IntStream.range(0, 117).mapToObj(Integer::valueOf).forEach(i -> {
-                OrderedFastHashMap.Entry<Integer, Integer> e = m.getEntry(m.size() - i - 1);
-                assertEquals(i, e.getKey());
-                assertEquals(i, e.getValue());
-            });
-        }
-        {
-            // many entries, even
-            final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(15);
-            IntStream.range(0, 80).mapToObj(Integer::valueOf).forEach(i -> m.put(i, i));
-            m.reverse();
-            IntStream.range(0, 80).mapToObj(Integer::valueOf).forEach(i -> {
-                OrderedFastHashMap.Entry<Integer, Integer> e = m.getEntry(m.size() - i - 1);
-                assertEquals(i, e.getKey());
-                assertEquals(i, e.getValue());
-            });
-        }
+    public void reverse_empty() {
+        // can reverse empty without exception
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.reverse();
+    }
+
+    @Test
+    public void reverse_zero_sized() {
+        // can reverse 0 sized map
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(0);
+        m.reverse();
+    }
+
+    @Test
+    public void reverse_one() {
+        // reverse one entry map
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("k0", "v0");
+        m.reverse();
+        assertEquals("k0", m.getEntry(0).getKey());
+        assertEquals("v0", m.getEntry(0).getValue());
+    }
+
+    @Test
+    public void reverse_two() {
+        // reverse two entries map
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("k0", "v0");
+        m.put("k1", "v1");
+        m.reverse();
+        assertEquals("k1", m.getEntry(0).getKey());
+        assertEquals("v1", m.getEntry(0).getValue());
+        assertEquals("k0", m.getEntry(1).getKey());
+        assertEquals("v0", m.getEntry(1).getValue());
+    }
+
+    @Test
+    public void reverse_three() {
+        // reverse three entries map
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("k0", "v0");
+        m.put("k1", "v1");
+        m.put("k2", "v2");
+        m.reverse();
+        assertEquals("k2", m.getEntry(0).getKey());
+        assertEquals("v2", m.getEntry(0).getValue());
+        assertEquals("k1", m.getEntry(1).getKey());
+        assertEquals("v1", m.getEntry(1).getValue());
+        assertEquals("k0", m.getEntry(2).getKey());
+        assertEquals("v0", m.getEntry(2).getValue());
+    }
+
+    @Test
+    public void reverse_many_odd() {
+        // many entries, odd
+        final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(15);
+        IntStream.range(0, 117).mapToObj(Integer::valueOf).forEach(i -> m.put(i, i));
+        m.reverse();
+
+        IntStream.range(0, 117).mapToObj(Integer::valueOf).forEach(i -> {
+            final OrderedFastHashMap.Entry<Integer, Integer> e = m.getEntry(m.size() - i - 1);
+            assertEquals(i, e.getKey());
+            assertEquals(i, e.getValue());
+        });
+    }
+
+    @Test
+    public void reverse_many_even() {
+        // many entries, even
+        final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(15);
+        IntStream.range(0, 80).mapToObj(Integer::valueOf).forEach(i -> m.put(i, i));
+        m.reverse();
+
+        IntStream.range(0, 80).mapToObj(Integer::valueOf).forEach(i -> {
+            final OrderedFastHashMap.Entry<Integer, Integer> e = m.getEntry(m.size() - i - 1);
+            assertEquals(i, e.getKey());
+            assertEquals(i, e.getValue());
+        });
     }
 
     static class MockKey<T extends Comparable<T>> implements Comparable<MockKey<T>> {
@@ -1419,7 +1508,7 @@ public class OrderedFastHashMapTest {
         }
 
         @Override
-        public int compareTo(MockKey<T> o) {
+        public int compareTo(final MockKey<T> o) {
             return o.key_.compareTo(this.key_);
         }
 

--- a/src/test/java/org/htmlunit/util/OrderedFastHashMapTest.java
+++ b/src/test/java/org/htmlunit/util/OrderedFastHashMapTest.java
@@ -1,0 +1,1396 @@
+/*
+ * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+@SuppressWarnings("checkstyle:AvoidNestedBlocks")
+public class OrderedFastHashMapTest {
+    @Test
+    public void ctr() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        assertEquals(0, m.size());
+        assertEquals(0, m.entrySet().size());
+        assertEquals(0, m.keys().size());
+        assertEquals(0, m.values().size());
+
+        assertNull(m.get("test"));
+    }
+
+    @Test
+    public void simplePut() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("K", "V");
+
+        assertEquals("V", m.get("K"));
+        assertEquals("K", m.getKey(0));
+        assertEquals("V", m.getValue(0));
+        assertEquals("V", m.getFirst());
+        assertEquals("V", m.getLast());
+
+        assertEquals("K", m.getEntry(0).getKey());
+        assertEquals("V", m.getEntry(0).getValue());
+    }
+
+    @Test
+    public void allowAnEmptyStart() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(0);
+        assertNull(m.get("K"));
+        assertNull(m.remove("K"));
+
+        m.put("K", "V");
+
+        assertEquals("V", m.get("K"));
+        assertEquals("K", m.getKey(0));
+        assertEquals("V", m.getValue(0));
+        assertEquals("V", m.getFirst());
+        assertEquals("V", m.getLast());
+
+        assertEquals("K", m.getEntry(0).getKey());
+        assertEquals("V", m.getEntry(0).getValue());
+    }
+
+    @Test
+    public void simpleMultiPut() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("K", "VK");
+        m.put("B", "VB");
+        m.put("A", "VA");
+        m.put("Z", "VZ");
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+        t.accept("K", 0);
+        t.accept("B", 1);
+        t.accept("A", 2);
+        t.accept("Z", 3);
+
+        // adding something last
+        m.put("0", "V0");
+        m.put("z", "Vz");
+
+        t.accept("K", 0);
+        t.accept("B", 1);
+        t.accept("A", 2);
+        t.accept("Z", 3);
+        t.accept("0", 4);
+        t.accept("z", 5);
+    }
+
+    @Test
+    public void putAgainDoesNotChangeOrder() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("K", "VK");
+        m.put("B", "VB");
+        m.put("A", "VA");
+        m.put("Z", "VZ");
+
+        m.put("B", "VB");
+        m.put("K", "VK");
+        m.put("Z", "VZ");
+        m.put("A", "VA");
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+        t.accept("K", 0);
+        t.accept("B", 1);
+        t.accept("A", 2);
+        t.accept("Z", 3);
+    }
+
+    @Test
+    public void getDoesNotChangeOrder() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("K", "VK");
+        m.put("B", "VB");
+        m.put("A", "VA");
+        m.put("Z", "VZ");
+
+        assertEquals("VZ", m.get("Z"));
+        assertEquals("VA", m.get("A"));
+        assertEquals("VB", m.get("B"));
+        assertEquals("VZ", m.get("Z"));
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+        t.accept("K", 0);
+        t.accept("B", 1);
+        t.accept("A", 2);
+        t.accept("Z", 3);
+    }
+
+    @Test
+    public void growSmall() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(3);
+        for (int i = 0; i < 10; i++) {
+            m.add(String.valueOf(i), "V" + String.valueOf(i));
+        }
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+        for (int i = 0; i < 10; i++) {
+            t.accept(String.valueOf(i), i);
+        }
+    }
+
+    @Test
+    public void growBig() {
+        final List<String> keys = new ArrayList<>();
+        final Random r = new Random();
+
+        for (int i = 0; i < 200; i++) {
+            final String key = RandomUtils.randomString(r, 3, 10);
+            keys.add(key);
+        }
+
+        // ok, we got random keys, our values will be V + its key
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(10);
+        for (final String key : keys) {
+            m.put(key, "V" + key);
+        }
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+
+        // ok, order will match when asking for keys
+        for (int i = 0; i < 200; i++) {
+            t.accept(keys.get(i), i);
+        }
+    }
+
+    @Test
+    public void keys() {
+        final OrderedFastHashMap<String, Integer> f = new OrderedFastHashMap<>(3);
+        f.put("aa", 1);
+        f.put("bb", 2);
+        f.put("cc", 3);
+        f.put("dd", 4);
+        f.put("ee", 5);
+
+        {
+            final List<String> k = f.keys();
+            assertEquals(5, k.size());
+            assertTrue(k.contains("aa"));
+            assertTrue(k.contains("bb"));
+            assertTrue(k.contains("cc"));
+            assertTrue(k.contains("dd"));
+            assertTrue(k.contains("ee"));
+        }
+
+        assertEquals(Integer.valueOf(3), f.remove("cc"));
+        f.remove("c");
+        {
+            final List<String> k = f.keys();
+            assertEquals(4, k.size());
+            assertTrue(k.contains("aa"));
+            assertTrue(k.contains("bb"));
+            assertTrue(k.contains("dd"));
+            assertTrue(k.contains("ee"));
+        }
+
+        f.put("zz", 10);
+        f.remove("c");
+        {
+            final List<String> k = f.keys();
+            assertEquals(5, k.size());
+            assertTrue(k.contains("aa"));
+            assertTrue(k.contains("bb"));
+            assertTrue(k.contains("dd"));
+            assertTrue(k.contains("ee"));
+            assertTrue(k.contains("zz"));
+        }
+
+        // ask for something unknown
+        assertNull(f.get("unknown"));
+    }
+
+    @Test
+    public void values() {
+        final OrderedFastHashMap<String, Integer> f = new OrderedFastHashMap<>(3);
+        f.put("aa", 1);
+        f.put("bb", 2);
+        f.put("cc", 3);
+        f.put("dd", 4);
+        f.put("ee", 5);
+
+        {
+            final List<Integer> values = f.values();
+            assertEquals(5, values.size());
+            assertTrue(values.contains(1));
+            assertTrue(values.contains(2));
+            assertTrue(values.contains(3));
+            assertTrue(values.contains(4));
+            assertTrue(values.contains(5));
+        }
+
+        assertEquals(Integer.valueOf(3), f.remove("cc"));
+        f.remove("c");
+        {
+            final List<Integer> values = f.values();
+            assertEquals(4, values.size());
+            assertTrue(values.contains(1));
+            assertTrue(values.contains(2));
+            assertTrue(values.contains(4));
+            assertTrue(values.contains(5));
+        }
+    }
+
+    @Test
+    public void remove_simple() {
+        {
+            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+            // remove instantly
+            m1.put("b", "value");
+            assertEquals("value", m1.remove("b"));
+            assertEquals(0, m1.size());
+        }
+
+        // remove the one before
+        {
+            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+            m1.put("b", "bvalue");
+            m1.put("c", "cvalue");
+            assertEquals("bvalue", m1.remove("b"));
+            assertEquals("cvalue", m1.get("c"));
+            assertEquals(1, m1.size());
+        }
+
+        // remove the one in the middle
+        {
+            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+            m1.put("a", "avalue");
+            m1.put("b", "bvalue");
+            m1.put("c", "cvalue");
+            assertEquals("bvalue", m1.remove("b"));
+            assertEquals("avalue", m1.get("a"));
+            assertEquals("cvalue", m1.get("c"));
+            assertEquals(2, m1.size());
+            assertEquals("a", m1.getKey(0));
+            assertEquals("c", m1.getKey(1));
+        }
+
+        // remove unknown
+        {
+            final OrderedFastHashMap<String, String> m1 = new OrderedFastHashMap<>();
+            assertNull(m1.remove("a"));
+            m1.put("b", "value");
+            assertNull(m1.remove("a"));
+        }
+    }
+
+    @Test
+    public void remove_complex() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(3);
+        m.put("b", "Vb1");
+        m.put("a", "Va");
+        m.put("d", "Vd1");
+        m.put("c", "Vc");
+        m.put("e", "Ve");
+
+        m.remove("b");
+        m.remove("d");
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+
+        assertEquals(3, m.size());
+        t.accept("a", 0);
+        t.accept("c", 1);
+        t.accept("e", 2);
+        assertNull(m.get("d"));
+        assertNull(m.get("b"));
+
+        // remove again
+        assertNull(m.remove("b"));
+        assertNull(m.remove("d"));
+
+        m.put("d", "Vd");
+        m.put("b", "Vb");
+
+        t.accept("a", 0);
+        t.accept("c", 1);
+        t.accept("e", 2);
+        t.accept("d", 3);
+        t.accept("b", 4);
+    }
+
+    @Test
+    public void removeRandomlyToEmpty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(15);
+        final Set<String> keys = new HashSet<>();
+        final Random r = new Random();
+
+        for (int i = 0; i < 1000; i++) {
+            final String key = RandomUtils.randomString(r, 1, 10);
+            keys.add(key); // just in case we have double keys generated
+            m.put(key, "V" + key);
+        }
+        assertEquals(keys.size(), m.size());
+
+        keys.forEach(key -> {
+            assertEquals("V" + key, m.get(key));
+            m.remove(key);
+            assertNull(m.get(key));
+        });
+        assertEquals(0, m.size());
+    }
+
+    @Test
+    public void removeTryingToCoverEdges_Last() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        for (int i = 0; i < 200; i++) {
+            // we add two, but immediately remove the last again
+            m.put(String.valueOf(i), "V" + String.valueOf(i));
+            m.put(String.valueOf(i + 1), "any");
+            assertEquals("any", m.remove(String.valueOf(i + 1)));
+        }
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+
+        assertEquals(200, m.size());
+        for (int i = 0; i < 200; i++) {
+            t.accept(String.valueOf(i), i);
+        }
+    }
+
+    @Test
+    public void removeTryingToCoverEdges_First() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        for (int i = 0; i < 4000; i = i + 2) {
+            m.put(String.valueOf(i), "any");
+            m.put(String.valueOf(i + 1), "V" + String.valueOf(i + 1));
+            assertEquals("any", m.remove(String.valueOf(i)));
+        }
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+
+        assertEquals(2000, m.size());
+        for (int i = 0; i < 4000; i = i + 2) {
+            t.accept(String.valueOf(i + 1), i / 2);
+        }
+    }
+
+    @Test
+    public void removeTryingToCoverEdges_Middle() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        for (int i = 0; i < 3 * 1972; i = i + 3) {
+            m.put(String.valueOf(i), "V" + String.valueOf(i));
+            m.put(String.valueOf(i + 1), "any");
+            m.put(String.valueOf(i + 2), "V" + String.valueOf(i + 2));
+            assertEquals("any", m.remove(String.valueOf(i + 1)));
+        }
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+
+        assertEquals(2 * 1972, m.size());
+        for (int i = 0, pos = 0; i < 3 * 1972; i = i + 3, pos = pos + 2) {
+            t.accept(String.valueOf(i), pos);
+            t.accept(String.valueOf(i + 2), pos + 1);
+        }
+    }
+
+    @Test
+    public void removeByIndex() {
+        {
+            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+            m.put("a", 1);
+            m.put("b", 2);
+            m.put("c", 3);
+            m.remove(0);
+
+            assertEquals("b", m.getKey(0));
+            assertEquals("c", m.getKey(1));
+            assertEquals(2, m.size());
+        }
+        {
+            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+            m.put("a", 1);
+            m.put("b", 2);
+            m.put("c", 3);
+            m.remove(1);
+
+            assertEquals("a", m.getKey(0));
+            assertEquals("c", m.getKey(1));
+            assertEquals(2, m.size());
+        }
+        {
+            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+            m.put("a", 1);
+            m.put("b", 2);
+            m.put("c", 3);
+            m.remove(2);
+
+            assertEquals("a", m.getKey(0));
+            assertEquals("b", m.getKey(1));
+            assertEquals(2, m.size());
+        }
+        {
+            final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+            m.put("a", 1);
+            m.put("b", 2);
+            m.put("c", 3);
+            m.remove(1);
+            m.remove(1);
+            m.remove(0);
+
+            assertEquals(0, m.size());
+        }
+    }
+
+    @Test
+    public void clear() {
+        final OrderedFastHashMap<String, Integer> m = new OrderedFastHashMap<String, Integer>();
+        m.put("a", 1);
+        assertEquals(1, m.size());
+
+        m.clear();
+        assertEquals(0, m.size());
+        assertEquals(0, m.keys().size());
+        assertEquals(0, m.values().size());
+        assertNull(m.get("a"));
+
+        m.put("b", 2);
+        assertEquals(1, m.size());
+        m.put("a", 3);
+        assertEquals(2, m.size());
+
+        m.clear();
+        assertEquals(0, m.size());
+        assertEquals(0, m.keys().size());
+        assertEquals(0, m.values().size());
+
+        m.put("a", 1);
+        m.put("b", 2);
+        m.put("c", 3);
+        m.put("c", 3);
+        assertEquals(3, m.size());
+        assertEquals(3, m.keys().size());
+        assertEquals(3, m.values().size());
+
+        assertEquals(Integer.valueOf(1), m.get("a"));
+        assertEquals(Integer.valueOf(2), m.get("b"));
+        assertEquals(Integer.valueOf(3), m.get("c"));
+    }
+
+    @Test
+    public void removeLast() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        final Random r1 = new Random(144L);
+
+        // empty is null
+        assertNull(m.removeLast());
+
+        for (int i = 0; i < 3 * 1972; i++) {
+            final String key = RandomUtils.randomString(r1, 20);
+            final String value = "V" + key;
+
+            m.put(key, value);
+            assertEquals(value, m.removeLast());
+            m.put(key, value);
+        }
+        assertEquals(3 * 1972, m.size());
+
+        BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+
+        final Random r2 = new Random(144L);
+        for (int i = 0; i < 3 * 1972; i++) {
+            final String key = RandomUtils.randomString(r2, 20);
+            t.accept(key, i);
+        }
+
+        final Random r3 = new Random(144L);
+        for (int i = 0; i < 3 * 1972; i++) {
+            final String key = RandomUtils.randomString(r3, 2, 10);
+            m.removeLast();
+        }
+        assertEquals(0, m.size());
+    }
+
+    @Test
+    public void removeFirst_Empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        assertNull(m.removeFirst());
+        assertEquals(0, m.size());
+    }
+
+    @Test
+    public void removeFirst_One() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("u", "Vu");
+        assertEquals("Vu", m.removeFirst());
+        assertEquals(0, m.size());
+    }
+
+    @Test
+    public void removeFirst_Two() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        m.put("u", "Vu");
+        m.put("a", "Va");
+        assertEquals("Vu", m.removeFirst());
+        assertEquals(1, m.size());
+        assertEquals("a", m.getKey(0));
+        assertEquals("Va", m.getValue(0));
+    }
+
+    @Test
+    public void removeFirst_WithGrowth() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(3);
+        final Random r = new Random(98765244L);
+        final List<String> keys = new ArrayList<>();
+
+        final BiConsumer<String, Integer> t = (k, index) -> {
+            assertEquals("V" + k, m.get(k));
+            assertEquals(k, m.getKey(index));
+            assertEquals("V" + k, m.getValue(index));
+        };
+
+        for (int i = 1; i < 1992; i++) {
+            keys.clear();
+            m.clear();
+
+            // setup entries
+            for (int e = 0; e < i; e++) {
+                final String k = RandomUtils.randomString(r, 20);
+                keys.add(k);
+            }
+
+            // add these all and remove first
+            for (String k : keys) {
+                m.put(k, "V" + k);
+            }
+            // remove first
+            final String rk = keys.remove(0);
+            assertEquals("V" + rk, m.removeFirst());
+
+            // add back
+            m.put(rk, "V" + rk);
+            keys.add(rk);
+
+            // verify
+            assertEquals(keys.size(), m.size());
+
+            // order of things
+            for (int e = 0; e < keys.size(); e++) {
+                t.accept(keys.get(e), e);
+            }
+        }
+    }
+
+    @Test
+    public void addFirst() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.addFirst("a", "1");
+            assertEquals(1, m.size());
+            assertEquals("a", m.getKey(0));
+            assertEquals("1", m.getValue(0));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.addFirst("a", "1");
+            m.addFirst("b", "2");
+            assertEquals(2, m.size());
+            assertEquals("a", m.getKey(1));
+            assertEquals("1", m.getValue(1));
+            assertEquals("b", m.getKey(0));
+            assertEquals("2", m.getValue(0));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.add("a", "1");
+            m.addFirst("b", "2");
+            assertEquals(2, m.size());
+            assertEquals("a", m.getKey(1));
+            assertEquals("1", m.getValue(1));
+            assertEquals("b", m.getKey(0));
+            assertEquals("2", m.getValue(0));
+        }
+    }
+
+    @Test
+    public void addLast() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.addLast("a", "1");
+            assertEquals(1, m.size());
+            assertEquals("a", m.getKey(0));
+            assertEquals("1", m.getValue(0));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.addLast("a", "1");
+            m.addLast("b", "2");
+            assertEquals(2, m.size());
+            assertEquals("a", m.getKey(0));
+            assertEquals("1", m.getValue(0));
+            assertEquals("b", m.getKey(1));
+            assertEquals("2", m.getValue(1));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.add("a", "1");
+            m.addLast("b", "2");
+            assertEquals(2, m.size());
+            assertEquals("a", m.getKey(0));
+            assertEquals("1", m.getValue(0));
+            assertEquals("b", m.getKey(1));
+            assertEquals("2", m.getValue(1));
+        }
+    }
+
+    @Test
+    public void containsKey_Empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        assertFalse(m.containsKey("akey"));
+    }
+
+    @Test
+    public void containsKey_True() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey", "any");
+            assertTrue(m.containsKey("akey"));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey1", "any");
+            m.put("akey2", "any");
+            m.put("akey3", "any");
+            m.put("akey4", "any");
+            assertTrue(m.containsKey("akey2"));
+            assertTrue(m.containsKey(new String("akey2")));
+        }
+        {
+            // same hash and same content
+            final OrderedFastHashMap<MockKey<String>, String> m = new OrderedFastHashMap<>();
+            final MockKey<String> mockKey1 = new MockKey<>(10, "akey1");
+            m.put(mockKey1, "any1");
+            m.put(new MockKey<String>(10, "akey2"), "any2");
+            m.put(new MockKey<String>(10, "akey3"), "any3");
+            m.put(new MockKey<String>(10, "akey4"), "any4");
+            assertTrue(m.containsKey(mockKey1));
+            assertTrue(m.containsKey(new MockKey<>(10, "akey1")));
+        }
+    }
+
+    @Test
+    public void containsKey_False() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey", "any");
+            assertFalse(m.containsKey("akey1"));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey1", "any");
+            m.put("akey2", "any");
+            m.put("akey3", "any");
+            assertFalse(m.containsKey("akey"));
+        }
+        {
+            // same hash but different content and same content different hash
+            final OrderedFastHashMap<MockKey<String>, String> m = new OrderedFastHashMap<>();
+            m.put(new MockKey<String>(10, "akey2"), "any2");
+            m.put(new MockKey<String>(10, "akey3"), "any3");
+            m.put(new MockKey<String>(10, "akey4"), "any4");
+            assertFalse(m.containsKey(new MockKey<>(10, "akey")));
+            assertFalse(m.containsKey(new MockKey<>(114, "akey2")));
+            assertFalse(m.containsKey(new MockKey<>(113, "akey3")));
+            assertFalse(m.containsKey(new MockKey<>(112, "akey4")));
+        }
+    }
+
+    @Test
+    public void containsValue_Empty() {
+        final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+        assertFalse(m.containsValue("avalue"));
+    }
+
+    @Test
+    public void containsValue_True() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey3", "any");
+            assertTrue(m.containsValue("any"));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey1", "any1");
+            m.put("akey2", "any2");
+            m.put("akey3", "any3");
+            assertTrue(m.containsValue("any1"));
+            assertTrue(m.containsValue("any2"));
+            assertTrue(m.containsValue("any3"));
+            assertTrue(m.containsValue(new String("any1")));
+            assertTrue(m.containsValue(new String("any2")));
+            assertTrue(m.containsValue(new String("any3")));
+        }
+    }
+
+    @Test
+    public void containsValue_False() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey3", "any");
+            assertFalse(m.containsValue("asdf"));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("akey1", "any1");
+            m.put("akey2", "any2");
+            m.put("akey3", "any3");
+            assertFalse(m.containsValue("akey1"));
+            assertFalse(m.containsValue("akey2"));
+            assertFalse(m.containsValue("akey3"));
+        }
+    }
+
+    @Test
+    public void isEmpty() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            assertTrue(m.isEmpty());
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("aaa", "a");
+            assertFalse(m.isEmpty());
+        }
+    }
+
+    @Test
+    public void entry() {
+        final Map<String, String> m = new OrderedFastHashMap<>();
+        m.put("K1", "V1");
+        m.put("K2", "V1");
+        final Entry<String, String> e = m.entrySet().iterator().next();
+
+        Iterator<Entry<String, String>> i = m.entrySet().iterator();
+        final Entry<String, String> e1 = i.next(); // K1, V1
+        final Entry<String, String> e2 = i.next(); // K2, V1
+
+        m.put("K1", "V2");
+        i = m.entrySet().iterator();
+        final Entry<String, String> e3 = i.next(); // K1, V2
+
+        // making sure we have all sub methods covered
+        assertEquals("K1", e.getKey());
+        assertEquals("V1", e.getValue());
+        assertEquals(e.getKey().hashCode() ^ e.getValue().hashCode(), e.hashCode());
+        assertEquals("K1=V1", e.toString());
+
+        assertTrue(e.equals(e));
+
+        assertTrue(e1.equals(e));
+        assertTrue(e.equals(e1));
+
+        assertFalse(e.equals(e2));
+        assertFalse(e2.equals(e));
+
+        assertFalse(e.equals(e2));
+        assertFalse(e3.equals(e));
+
+        assertFalse(e.equals("k"));
+
+        assertThrows(UnsupportedOperationException.class, () -> e.setValue("foo"));
+    }
+
+    @Test
+    public void entrySet() {
+        {
+            OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            final Set<Entry<String, String>> set = m.entrySet();
+            assertEquals(0, set.size());
+            assertTrue(set.isEmpty());
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("K1", "V1");
+            final Set<Entry<String, String>> set = m.entrySet();
+            assertEquals(1, set.size());
+            assertFalse(set.isEmpty());
+
+            final Entry<String, String> e1 = set.iterator().next();
+            assertEquals("K1", e1.getKey());
+            assertEquals("V1", e1.getValue());
+
+            final Map<String, String> map = new LinkedHashMap<>();
+            map.put("K1", "V1");
+            map.put("K2", "V1");
+            Iterator<Map.Entry<String, String>> i = map.entrySet().iterator();
+            final Entry<String, String> e2 = i.next();
+            final Entry<String, String> e3 = i.next();
+
+            assertTrue(set.contains(e1));
+            assertTrue(set.contains(e2));
+
+            assertFalse(set.contains("a"));
+            assertFalse(set.contains(e3));
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            IntStream.rangeClosed(0, 11).forEach(i -> m.put("K" + i, "V" + i));
+            final Set<Entry<String, String>> set = m.entrySet();
+            assertEquals(12, set.size());
+            assertFalse(set.isEmpty());
+
+            final Iterator<Entry<String, String>> iter = set.iterator();
+            IntStream.rangeClosed(0, 11).forEach(i -> {
+                assertTrue(iter.hasNext());
+                final Entry<String, String> e = iter.next();
+                assertEquals("K" + i, e.getKey());
+                assertEquals("V" + i, e.getValue());
+            });
+            assertFalse(iter.hasNext());
+
+            // overread
+            assertThrows(NoSuchElementException.class, () -> iter.next());
+        }
+    }
+
+    @Test
+    public void entrySet_toArray() {
+        {
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            final Set<Entry<String, String>> set = m.entrySet();
+            assertEquals(0, set.toArray().length);
+            assertEquals(0, set.toArray(new Map.Entry[0]).length);
+            assertEquals(10, set.toArray(new String[10]).length);
+
+            // unfilled despite length 10
+            final String[] a = set.toArray(new String[10]);
+            for (int i = 0; i < 10; i++) {
+                assertNull(a[i]);
+            }
+        }
+        {
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            m.put("K1", "V1");
+            final Set<Entry<String, String>> set = m.entrySet();
+            assertEquals(1, set.toArray().length);
+            assertEquals(1, set.toArray(new Map.Entry[0]).length);
+            assertEquals(1, set.toArray(new Map.Entry[1]).length);
+
+            assertNotNull(set.toArray()[0]);
+            assertEquals("K1", ((Map.Entry<String, String>) set.toArray()[0]).getKey());
+            assertEquals("V1", ((Map.Entry<String, String>) set.toArray()[0]).getValue());
+
+            assertEquals("K1", set.toArray(new Map.Entry[0])[0].getKey());
+            assertEquals("V1", set.toArray(new Map.Entry[0])[0].getValue());
+
+            assertEquals("K1", set.toArray(new Map.Entry[1])[0].getKey());
+            assertEquals("V1", set.toArray(new Map.Entry[1])[0].getValue());
+        }
+        {
+            // ensure we get our array back when it is sufficiently sized
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            m.put("K1", "V1");
+            final Set<Entry<String, String>> set = m.entrySet();
+
+            // right sized
+            final Map.Entry[] array1 = new Map.Entry[1];
+            assertSame(array1, set.toArray(array1));
+
+            // oversized
+            final Map.Entry[] array2 = new Map.Entry[10];
+            assertSame(array2, set.toArray(array2));
+        }
+        {
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
+            final Object[] a1 = m.entrySet().toArray();
+            final Map.Entry[] a2 = m.entrySet().toArray(new Map.Entry[45]);
+            assertEquals(45, a1.length);
+            assertEquals(45, a2.length);
+
+            for (int i = 0; i <= 44; i++) {
+                assertEquals("K" + i, ((Map.Entry<String, String>) a1[i]).getKey());
+                assertEquals("V" + i, ((Map.Entry<String, String>) a1[i]).getValue());
+
+                assertEquals("K" + i, a2[i].getKey());
+                assertEquals("V" + i, a2[i].getValue());
+            }
+            ;
+        }
+    }
+
+    @Test
+    public void keySet() {
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            final Set<String> set = m.keySet();
+            assertEquals(0, set.size());
+            assertTrue(set.isEmpty());
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("K1", "V1");
+            final Set<String> set = m.keySet();
+            assertEquals(1, set.size());
+            assertFalse(set.isEmpty());
+
+            final String e1 = set.iterator().next();
+            assertEquals("K1", e1);
+        }
+        {
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
+            final Set<String> set = m.keySet();
+            assertEquals(45, set.size());
+            assertFalse(set.isEmpty());
+
+            final Iterator<String> iter = set.iterator();
+            IntStream.rangeClosed(0, 44).forEach(i -> {
+                assertTrue(iter.hasNext());
+                final String e = iter.next();
+                assertEquals("K" + i, e);
+                assertTrue(set.contains("K" + i));
+            });
+            assertFalse(iter.hasNext());
+
+            // overread
+            assertThrows(NoSuchElementException.class, () -> iter.next());
+        }
+    }
+
+    @Test
+    public void keySet_toArray() {
+        {
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            final Set<String> set = m.keySet();
+            assertEquals(0, set.toArray().length);
+            assertEquals(0, set.toArray(new String[0]).length);
+            assertEquals(10, set.toArray(new String[10]).length);
+
+            // unfilled despite length 10
+            String[] a = set.toArray(new String[10]);
+            for (int i = 0; i < 10; i++) {
+                assertNull(a[i]);
+            }
+        }
+        {
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            m.put("K1", "V1");
+            final Set<String> set = m.keySet();
+            assertEquals(1, set.toArray().length);
+            assertEquals(1, set.toArray(new String[0]).length);
+            assertEquals(1, set.toArray(new String[1]).length);
+
+            assertEquals("K1", set.toArray()[0]);
+            assertEquals("K1", set.toArray(new String[0])[0]);
+            assertEquals("K1", set.toArray(new String[1])[0]);
+        }
+        {
+            // ensure we get our array back when it is sufficiently sized
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            m.put("K1", "V1");
+            final Set<String> set = m.keySet();
+
+            // right sized
+            String[] array1 = new String[1];
+            assertSame(array1, set.toArray(array1));
+
+            // oversized
+            String[] array2 = new String[10];
+            assertSame(array2, set.toArray(array2));
+        }
+        {
+            final Map<String, String> m = new OrderedFastHashMap<>();
+            IntStream.rangeClosed(0, 44).forEach(i -> m.put("K" + i, "V" + i));
+            final Object[] a1 = m.keySet().toArray();
+            final String[] a2 = m.keySet().toArray(new String[45]);
+            assertEquals(45, a1.length);
+            assertEquals(45, a2.length);
+
+            for (int i = 0; i <= 44; i++) {
+                assertEquals("K" + i, a1[i]);
+                assertEquals("K" + i, a2[i]);
+            }
+            ;
+        }
+    }
+
+    @Test
+    public void putAll() {
+        {
+            // we cannot add ourselves!
+            IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+                OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+                m.putAll(m);
+            });
+            assertEquals("Cannot add myself", thrown.getMessage());
+        }
+        {
+            // empty
+            final Map<String, String> src = new HashMap<>();
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.putAll(src);
+            assertEquals(0, m.size());
+        }
+        {
+            // target empty
+            final Map<String, String> src = new LinkedHashMap<>();
+            IntStream.rangeClosed(0, 10).forEach(i -> src.put("K" + i, "V" + i));
+
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.putAll(src);
+            assertEquals(11, m.size());
+
+            final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
+            IntStream.rangeClosed(0, 10).forEach(i -> {
+                assertTrue(iter.hasNext());
+                final Entry<String, String> e = iter.next();
+                assertEquals("K" + i, e.getKey());
+                assertEquals("V" + i, e.getValue());
+            });
+            assertFalse(iter.hasNext());
+        }
+        {
+            // src empty
+            final Map<String, String> src = new LinkedHashMap<>();
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("K1", "V1");
+
+            m.putAll(src);
+            assertEquals(1, m.size());
+
+            final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
+            assertTrue(iter.hasNext());
+            final Entry<String, String> e = iter.next();
+            assertEquals("K1", e.getKey());
+            assertEquals("V1", e.getValue());
+            assertFalse(iter.hasNext());
+        }
+        {
+            // target not empty
+            final Map<String, String> src = new LinkedHashMap<>();
+            IntStream.rangeClosed(0, 17).forEach(i -> src.put("SRCK" + i, "SRCV" + i));
+
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            IntStream.rangeClosed(100, 111).forEach(i -> m.put("K" + i, "V" + i));
+
+            m.putAll(src);
+            assertEquals(12 + 18, m.size());
+
+            final Iterator<Entry<String, String>> iter = m.entrySet().iterator();
+            IntStream.rangeClosed(100, 111).forEach(i -> {
+                assertTrue(iter.hasNext());
+                final Entry<String, String> e = iter.next();
+                assertEquals("K" + i, e.getKey());
+                assertEquals("V" + i, e.getValue());
+            });
+            assertTrue(iter.hasNext());
+            IntStream.rangeClosed(0, 17).forEach(i -> {
+                assertTrue(iter.hasNext());
+                final Entry<String, String> e = iter.next();
+                assertEquals("SRCK" + i, e.getKey());
+                assertEquals("SRCV" + i, e.getValue());
+            });
+            assertFalse(iter.hasNext());
+        }
+        {
+            // same type but not same map
+            final OrderedFastHashMap<String, String> src = new OrderedFastHashMap<>();
+            IntStream.rangeClosed(19, 99).forEach(i -> src.put("K" + i, "V" + i));
+
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            IntStream.rangeClosed(0, 18).forEach(i -> m.put("K" + i, "V" + i));
+
+            m.putAll(src);
+            assertEquals(100, m.size());
+
+            final Set<Entry<String, String>> set = m.entrySet();
+            final Iterator<Entry<String, String>> iter = set.iterator();
+            IntStream.rangeClosed(0, 99).forEach(i -> {
+                assertTrue(iter.hasNext());
+                final Entry<String, String> e = iter.next();
+                assertEquals("K" + i, e.getKey());
+                assertEquals("K" + i, e.getKey());
+                assertEquals("V" + i, e.getValue());
+            });
+            assertFalse(iter.hasNext());
+        }
+        {
+            // I can be added to other Map.putAll
+            final Map<String, String> src = new OrderedFastHashMap<>();
+            final Map<String, String> m = new HashMap<>();
+            m.putAll(src);
+            assertEquals(0, m.size());
+        }
+    }
+
+    @Test
+    public void collision() {
+        OrderedFastHashMap<MockKey<String>, String> f = new OrderedFastHashMap<MockKey<String>, String>(13);
+        IntStream.range(0, 15).forEach(i -> {
+            f.put(new MockKey<String>(12, "k" + i), "v" + i);
+        });
+
+        assertEquals(15, f.size());
+
+        IntStream.range(0, 15).forEach(i -> {
+            assertEquals("v" + i, f.get(new MockKey<String>(12, "k" + i)));
+        });
+
+        // round 2
+        IntStream.range(0, 20).forEach(i -> {
+            f.put(new MockKey<String>(12, "k" + i), "v" + i);
+        });
+
+        assertEquals(20, f.size());
+
+        IntStream.range(0, 20).forEach(i -> {
+            assertEquals("v" + i, f.get(new MockKey<String>(12, "k" + i)));
+        });
+
+        // round 3
+        IntStream.range(0, 10).forEach(i -> {
+            assertEquals("v" + i, f.remove(new MockKey<String>(12, "k" + i)));
+        });
+        IntStream.range(10, 20).forEach(i -> {
+            assertEquals("v" + i, f.get(new MockKey<String>(12, "k" + i)));
+        });
+    }
+
+    /**
+     * Overflow initial size with collision keys. Some hash code for all keys.
+     */
+    @Test
+    public void overflow() {
+        final OrderedFastHashMap<MockKey<String>, Integer> m = new OrderedFastHashMap<>(5);
+        final Map<MockKey<String>, Integer> data = IntStream.range(0, 152).mapToObj(Integer::valueOf)
+                .collect(Collectors.toMap(i -> new MockKey<String>(1, "k" + i), i -> i));
+
+        // add all
+        data.forEach((k, v) -> m.put(k, v));
+
+        // verify
+        data.forEach((k, v) -> assertEquals(v, m.get(k)));
+        assertEquals(152, m.size());
+        assertEquals(152, m.keys().size());
+        assertEquals(152, m.values().size());
+    }
+
+    /**
+     * Try to hit all slots with bad hashcodes
+     */
+    @Test
+    public void hitEachSlot() {
+        final OrderedFastHashMap<MockKey<String>, Integer> m = new OrderedFastHashMap<>(15);
+
+        final Map<MockKey<String>, Integer> data = IntStream.range(0, 150).mapToObj(Integer::valueOf)
+                .collect(Collectors.toMap(i -> new MockKey<String>(i, "k1" + i), i -> i));
+
+        // add the same hash codes again but other keys
+        data.putAll(IntStream.range(0, 150).mapToObj(Integer::valueOf)
+                .collect(Collectors.toMap(i -> new MockKey<String>(i, "k2" + i), i -> i)));
+        // add all
+        data.forEach((k, v) -> m.put(k, v));
+        // verify
+        data.forEach((k, v) -> assertEquals(v, m.get(k)));
+        assertEquals(300, m.size());
+        assertEquals(300, m.keys().size());
+        assertEquals(300, m.values().size());
+
+        // remove all
+        data.forEach((k, v) -> m.remove(k));
+        // verify
+        assertEquals(0, m.size());
+        assertEquals(0, m.keys().size());
+        assertEquals(0, m.values().size());
+
+        // add all
+        final List<MockKey<String>> keys = data.keySet().stream().collect(Collectors.toList());
+        keys.stream().sorted().forEach(k -> m.put(k, data.get(k)));
+        // put in different order
+        Collections.shuffle(keys);
+        keys.forEach(k -> m.put(k, data.get(k) + 42));
+
+        // verify
+        data.forEach((k, v) -> assertEquals(Integer.valueOf(v + 42), m.get(k)));
+        assertEquals(300, m.size());
+        assertEquals(300, m.keys().size());
+        assertEquals(300, m.values().size());
+
+        // remove in different order
+        Collections.shuffle(keys);
+        keys.forEach(k -> m.remove(k));
+
+        // verify
+        data.forEach((k, v) -> assertNull(m.get(k)));
+        assertEquals(0, m.size());
+        assertEquals(0, m.keys().size());
+        assertEquals(0, m.values().size());
+    }
+
+    @Test
+    public void reverse() {
+        {
+            // can reverse empty without exception
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.reverse();
+        }
+        {
+            // can reverse 0 sized map
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>(0);
+            m.reverse();
+        }
+        {
+            // reverse one entry map
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("k0", "v0");
+            m.reverse();
+            assertEquals("k0", m.getEntry(0).getKey());
+            assertEquals("v0", m.getEntry(0).getValue());
+        }
+        {
+            // reverse two entries map
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("k0", "v0");
+            m.put("k1", "v1");
+            m.reverse();
+            assertEquals("k1", m.getEntry(0).getKey());
+            assertEquals("v1", m.getEntry(0).getValue());
+            assertEquals("k0", m.getEntry(1).getKey());
+            assertEquals("v0", m.getEntry(1).getValue());
+        }
+        {
+            // reverse three entries map
+            final OrderedFastHashMap<String, String> m = new OrderedFastHashMap<>();
+            m.put("k0", "v0");
+            m.put("k1", "v1");
+            m.put("k2", "v2");
+            m.reverse();
+            assertEquals("k2", m.getEntry(0).getKey());
+            assertEquals("v2", m.getEntry(0).getValue());
+            assertEquals("k1", m.getEntry(1).getKey());
+            assertEquals("v1", m.getEntry(1).getValue());
+            assertEquals("k0", m.getEntry(2).getKey());
+            assertEquals("v0", m.getEntry(2).getValue());
+        }
+        {
+            // many entries, odd
+            final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(15);
+            IntStream.range(0, 117).mapToObj(Integer::valueOf).forEach(i -> m.put(i, i));
+            m.reverse();
+            IntStream.range(0, 117).mapToObj(Integer::valueOf).forEach(i -> {
+                OrderedFastHashMap.Entry<Integer, Integer> e = m.getEntry(m.size() - i - 1);
+                assertEquals(i, e.getKey());
+                assertEquals(i, e.getValue());
+            });
+        }
+        {
+            // many entries, even
+            final OrderedFastHashMap<Integer, Integer> m = new OrderedFastHashMap<>(15);
+            IntStream.range(0, 80).mapToObj(Integer::valueOf).forEach(i -> m.put(i, i));
+            m.reverse();
+            IntStream.range(0, 80).mapToObj(Integer::valueOf).forEach(i -> {
+                OrderedFastHashMap.Entry<Integer, Integer> e = m.getEntry(m.size() - i - 1);
+                assertEquals(i, e.getKey());
+                assertEquals(i, e.getValue());
+            });
+        }
+    }
+
+    static class MockKey<T extends Comparable<T>> implements Comparable<MockKey<T>> {
+        public final T key_;
+        public final int hash_;
+
+        MockKey(final int hash, final T key) {
+            this.hash_ = hash;
+            this.key_ = key;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash_;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            final MockKey<T> t = (MockKey<T>) o;
+            return hash_ == o.hashCode() && key_.equals(t.key_);
+        }
+
+        @Override
+        public String toString() {
+            return "MockKey [key=" + key_ + ", hash=" + hash_ + "]";
+        }
+
+        @Override
+        public int compareTo(MockKey<T> o) {
+            return o.key_.compareTo(this.key_);
+        }
+
+    }
+}

--- a/src/test/java/org/htmlunit/util/RandomUtils.java
+++ b/src/test/java/org/htmlunit/util/RandomUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit.util;
+
+import java.util.Random;
+
+public final class RandomUtils {
+    private static final String LOWERCHARS = "abcdefghijklmnopqrstuvwxyz";
+    private static final String UPPERCHARS = LOWERCHARS.toUpperCase();
+    private static final String CHARS = LOWERCHARS + UPPERCHARS;
+
+    /**
+     * Private ctor to keep Checkstyle happy
+     */
+    private RandomUtils() {
+
+    }
+
+    /**
+     * Fixed length random string of lower case and uppercase chars.
+     *
+     * @param random the random number generator
+     * @param length the length of the resulting string
+     * @return a random string of the desired length
+     */
+    public static String randomString(final Random random, final int length) {
+        return randomString(random, length, length);
+    }
+
+    /**
+     * Variable length random string of lower case and upper case chars.
+     *
+     * @param random the random generator
+     * @param from min length
+     * @param to max length (inclusive)
+     * @return a random string
+     */
+    public static String randomString(final Random random, final int from, final int to) {
+        final int length = random.nextInt(to - from + 1) + from;
+
+        final StringBuilder sb = new StringBuilder(to);
+
+        for (int i = 0; i < length; i++) {
+            final int pos = random.nextInt(CHARS.length());
+            sb.append(CHARS.charAt(pos));
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/htmlunit/util/RandomUtils.java
+++ b/src/test/java/org/htmlunit/util/RandomUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023 Gargoyle Software Inc.
+ * Copyright (c) 2002-2024 Gargoyle Software Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
HtmlUnit tuning regarding speed and memory. Current success, more on the memory side.
Please run the full test program, there might be something hidden. The small one looked ok.

## E-commerce retailer website

### NEW (JDK 17)
```
Benchmark                                    Mode  Cnt        Score   Error   Units
HtmlUnitBenchmark.simple                     avgt    2  9639101.018           ns/op
HtmlUnitBenchmark.simple:gc.alloc.rate.norm  avgt    2  7612275.912            B/op
```

### OLD (JDK 17)
```
Benchmark                                    Mode  Cnt         Score   Error   Units
HtmlUnitBenchmark.simple                     avgt    2  10527569.765           ns/op
HtmlUnitBenchmark.simple:gc.alloc.rate.norm  avgt    2   9213538.844            B/op
``` 

## XC Homepage

### NEW (JDK 17)
```
Benchmark                                    Mode  Cnt       Score   Error   Units
HtmlUnitBenchmark.simple                     avgt    2  397427.602           ns/op
HtmlUnitBenchmark.simple:gc.alloc.rate.norm  avgt    2  383380.466            B/op
```
### OLD (JDK 17)
```
Benchmark                                    Mode  Cnt       Score   Error   Units
HtmlUnitBenchmark.simple                     avgt    2  411880.438           ns/op
HtmlUnitBenchmark.simple:gc.alloc.rate.norm  avgt    2  454900.410            B/op
```