### PR TITLE
HtmlTableCell: better handling of colspan / rowspan

### DIFF
--- a/src/main/java/org/htmlunit/html/HtmlTableCell.java
+++ b/src/main/java/org/htmlunit/html/HtmlTableCell.java
@@ -16,6 +16,7 @@ package org.htmlunit.html;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.htmlunit.SgmlPage;
 
 /**
@@ -48,7 +49,7 @@ public abstract class HtmlTableCell extends HtmlElement {
      * @return the value of the colspan attribute, or <code>1</code> if the attribute wasn't specified
      */
     public int getColumnSpan() {
-        final String spanString = getAttributeDirect("colspan");
+        final String spanString = StringUtils.replaceChars(getAttributeDirect("colspan"), "\r\n", null);
         if (spanString == null || spanString.isEmpty()) {
             return 1;
         }
@@ -65,7 +66,7 @@ public abstract class HtmlTableCell extends HtmlElement {
      * @return the value of the rowspan attribute, or <code>1</code> if the attribute wasn't specified
      */
     public int getRowSpan() {
-        final String spanString = getAttributeDirect("rowspan");
+        final String spanString = StringUtils.replaceChars(getAttributeDirect("rowspan"), "\r\n", null);
         if (spanString == null || spanString.isEmpty()) {
             return 1;
         }

--- a/src/main/java/org/htmlunit/html/HtmlTableCell.java
+++ b/src/main/java/org/htmlunit/html/HtmlTableCell.java
@@ -52,7 +52,12 @@ public abstract class HtmlTableCell extends HtmlElement {
         if (spanString == null || spanString.isEmpty()) {
             return 1;
         }
-        return Integer.parseInt(spanString);
+        try {
+            return Integer.parseInt(spanString);
+        }
+        catch (final NumberFormatException e) {
+            return 1;
+        }
     }
 
     /**
@@ -64,7 +69,12 @@ public abstract class HtmlTableCell extends HtmlElement {
         if (spanString == null || spanString.isEmpty()) {
             return 1;
         }
-        return Integer.parseInt(spanString);
+        try {
+            return Integer.parseInt(spanString);
+        }
+        catch (final NumberFormatException e) {
+            return 1;
+        }
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLTableCellElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLTableCellElement.java
@@ -27,6 +27,7 @@ import static org.htmlunit.javascript.configuration.SupportedBrowser.IE;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.htmlunit.css.ComputedCssStyleDeclaration;
 import org.htmlunit.css.StyleAttributes;
 import org.htmlunit.html.DomNode;
@@ -195,7 +196,7 @@ public class HTMLTableCellElement extends HTMLTableComponent {
      */
     @JsxGetter
     public int getColSpan() {
-        final String s = getDomNodeOrDie().getAttribute("colSpan");
+        final String s = StringUtils.replaceChars(getDomNodeOrDie().getAttribute("colSpan"), "\r\n", null);
         try {
             return Integer.parseInt(s);
         }
@@ -231,7 +232,7 @@ public class HTMLTableCellElement extends HTMLTableComponent {
      */
     @JsxGetter
     public int getRowSpan() {
-        final String s = getDomNodeOrDie().getAttribute("rowSpan");
+        final String s = StringUtils.replaceChars(getDomNodeOrDie().getAttribute("rowSpan"), "\r\n", null);
         try {
             return Integer.parseInt(s);
         }


### PR DESCRIPTION
### This PR does the following:
- Treat `rowspan` / `colspan` that cannot be parsed as "1" instead of throwing an exception, like standard browsers. (`HTMLTableCellElement` already behaves like this)
- Allow superfluous line breaks in `rowspan` / `colspan` like standard browsers. (Otherwise it will return 1 because span value cannot be parsed)