### PR TITLE
HtmlUnitUsernamePasswordCredentials: allow null passwords

### DIFF
--- a/src/main/java/org/htmlunit/httpclient/HtmlUnitUsernamePasswordCredentials.java
+++ b/src/main/java/org/htmlunit/httpclient/HtmlUnitUsernamePasswordCredentials.java
@@ -50,7 +50,7 @@ public class HtmlUnitUsernamePasswordCredentials implements Credentials, Seriali
      * @param password the password
      */
     public HtmlUnitUsernamePasswordCredentials(final String userName, final char[] password) {
-        httpClientUsernamePasswordCredentials_ = new UsernamePasswordCredentials(userName, String.valueOf(password));
+        httpClientUsernamePasswordCredentials_ = new UsernamePasswordCredentials(userName, password != null ? String.valueOf(password) : null);
     }
 
     @Override


### PR DESCRIPTION
### This PR does the following
- Restore the ability to specify `null` as password value which was removed by https://github.com/HtmlUnit/htmlunit/commit/b553025245ff2b509893b798db5c5a9304f0b96e. This allows the authentication scheme to handle null passwords as they see fit. (e.g. Basic auth converts it to the text "null".)