### PR TITLE
HtmlImage: fix Image.onload() being called immediately instead of later

### DIFF
--- a/src/main/java/org/htmlunit/html/HtmlImage.java
+++ b/src/main/java/org/htmlunit/html/HtmlImage.java
@@ -45,6 +45,7 @@ import org.htmlunit.SgmlPage;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
+import org.htmlunit.javascript.JavaScriptEngine;
 import org.htmlunit.javascript.PostponedAction;
 import org.htmlunit.javascript.host.dom.Document;
 import org.htmlunit.javascript.host.event.Event;
@@ -316,7 +317,19 @@ public class HtmlImage extends HtmlElement {
                 htmlPage.addAfterLoadAction(action);
             }
             else {
-                fireEvent(event);
+                JavaScriptEngine jsEngine = (JavaScriptEngine) client.getJavaScriptEngine();
+                if (jsEngine.isScriptRunning()) {
+                    final PostponedAction action = new PostponedAction(getPage(), "HtmlImage.doOnLoad") {
+                        @Override
+                        public void execute() {
+                            HtmlImage.this.fireEvent(event);
+                        }
+                    };
+                    jsEngine.addPostponedAction(action);
+                }
+                else {
+                    fireEvent(event);
+                }
             }
         }
     }

--- a/src/test/java/org/htmlunit/html/HtmlImageTest.java
+++ b/src/test/java/org/htmlunit/html/HtmlImageTest.java
@@ -317,4 +317,39 @@ public class HtmlImageTest extends SimpleWebTestCase {
         img.click(2, 7);
         assertEquals(getExpectedAlerts()[0] + getExpectedAlerts()[1], page.getTitleText());
     }
+
+    /**
+     * @throws Exception on test failure
+     */
+    @Test
+    @Alerts({"in-out-Image.onload(0)-", "mousedown-in-out-Image.onload(1)-mouseup-in-out-click-in-out-Image.onload(2)-Image.onload(3)-"})
+    public void onload() throws Exception {
+        final String html =
+                "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + "  function log(msg) { window.document.title += msg + '-';}\n"
+                + "  function test(i) {\n"
+                + "    log('in');\n"
+                + "    var image = new Image();\n"
+                + "    image.onload = function () { log(\"Image.onload(\" + i + \")\") };\n"
+                + "    image.src = '4x7.jpg';\n"
+                + "    log('out');\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload=\"test(0)\">\n"
+                + "<button onmousedown=\"log('mousedown'); test(1)\""
+                + "        onmouseup=\"log('mouseup'); test(2)\""
+                + "        onclick=\"log('click'); test(3)\"></button>\n"
+                + "</body>\n"
+                + "</html>\n";
+
+        final HtmlPage page = loadPage(html);
+        assertEquals(getExpectedAlerts()[0], page.getTitleText());
+
+        page.setTitleText("");
+        page.<HtmlButton>getFirstByXPath("//button").click();
+        assertEquals(getExpectedAlerts()[1], page.getTitleText());
+    }
 }


### PR DESCRIPTION
### This PR does the following:
- Fix a bug where `Image.onload()` is processed immediately rather than after the running JS code.

### Test cases used
```html
<html>
<head>
<script>
function test() {
    console.log('in');
    var image = new Image();
    image.onload = function () { console.log("Image.onload") };
    image.src = '1x1.png';
    console.log('out');
}
</script>
</head>
<body>
<button onclick="test()">test</button>
</body>
</html>
```

- Real browser: `in`, `out`, `Image.onload`
- HtmlUnit: `in`, `Image.onload`, `out`
