### PR TITLE
Fix issue and additional improvements with charset handling

### DIFF
--- a/src/main/java/org/htmlunit/util/EncodingSniffer.java
+++ b/src/main/java/org/htmlunit/util/EncodingSniffer.java
@@ -455,8 +455,8 @@ public final class EncodingSniffer {
                 i += META_START.length;
                 for (Attribute att = getAttribute(bytes, i); att != null; att = getAttribute(bytes, i)) {
                     i = att.getUpdatedIndex();
-                    final String name = att.getName();
-                    final String value = att.getValue();
+                    final String name = att.getName().toLowerCase(Locale.ROOT);
+                    final String value = att.getValue().toLowerCase(Locale.ROOT);
                     if ("charset".equals(name) || "content".equals(name)) {
                         Charset charset = null;
                         if ("charset".equals(name)) {

--- a/src/main/java/org/htmlunit/util/WebResponseWrapper.java
+++ b/src/main/java/org/htmlunit/util/WebResponseWrapper.java
@@ -71,6 +71,15 @@ public class WebResponseWrapper extends WebResponse {
 
     /**
      * {@inheritDoc}
+     * The default behavior of this method is to return wasContentCharsetTentative() on the wrapped webResponse object.
+     */
+    @Override
+    public boolean wasContentCharsetTentative() {
+        return wrappedWebResponse_.wasContentCharsetTentative();
+    }
+
+    /**
+     * {@inheritDoc}
      * The default behavior of this method is to return getContentAsString() on the wrapped webResponse object.
      */
     @Override

--- a/src/test/java/org/htmlunit/util/EncodingSnifferTest.java
+++ b/src/test/java/org/htmlunit/util/EncodingSnifferTest.java
@@ -80,6 +80,7 @@ public class EncodingSnifferTest {
         meta(UTF_8, "abc <meta http-equiv='Content-Type' content='text/html; charset=utf-8'/>");
         meta(UTF_8, "abc <meta http-equiv='Content-Type' content='text/html; CHARSET=UTF-8'/>");
         meta(UTF_8, "abc <meta http-equiv='Content-Type' content='text/html; chArsEt=UtF-8'/>");
+        meta(UTF_8, "<meta a='b' c=d e=\"f\" CONTENT='text/html; CHARSET=utf-8' />");
     }
 
     private static void meta(final Charset expectedEncoding, final String content) throws Exception {


### PR DESCRIPTION
This PR does the following
- Fix `WebResponseWrapper` by adding the missing `wasContentCharsetTentative()`
- Change `EncodingSniffer.sniffEncodingFromMetaTag()` meta tag parsing to case-insensitive