### PR TITLE
Support URL.createObjectURL() and URL.revokeObjectURL()

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/URL.java
+++ b/src/main/java/org/htmlunit/javascript/host/URL.java
@@ -21,6 +21,8 @@ import java.net.MalformedURLException;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.htmlunit.corejs.javascript.Context;
+import org.htmlunit.corejs.javascript.Scriptable;
 import org.htmlunit.javascript.HtmlUnitScriptable;
 import org.htmlunit.javascript.JavaScriptEngine;
 import org.htmlunit.javascript.configuration.JsxClass;
@@ -30,6 +32,7 @@ import org.htmlunit.javascript.configuration.JsxFunction;
 import org.htmlunit.javascript.configuration.JsxGetter;
 import org.htmlunit.javascript.configuration.JsxSetter;
 import org.htmlunit.javascript.configuration.JsxStaticFunction;
+import org.htmlunit.javascript.host.file.Blob;
 import org.htmlunit.javascript.host.file.File;
 import org.htmlunit.util.NameValuePair;
 import org.htmlunit.util.UrlUtils;
@@ -96,7 +99,12 @@ public class URL extends HtmlUnitScriptable {
     public static String createObjectURL(final Object fileOrBlob) {
         if (fileOrBlob instanceof File) {
             final File file = (File) fileOrBlob;
-            return file.getFile().toURI().normalize().toString();
+            return getWindow(file).getDocument().generateBlobUrl(file);
+        }
+
+        if (fileOrBlob instanceof Blob) {
+            final Blob blob = (Blob) fileOrBlob;
+            return getWindow(blob).getDocument().generateBlobUrl(blob);
         }
 
         return null;
@@ -107,7 +115,8 @@ public class URL extends HtmlUnitScriptable {
      *          created by calling URL.createObjectURL().
      */
     @JsxStaticFunction
-    public static void revokeObjectURL(final Object objectURL) {
+    public static void revokeObjectURL(final Scriptable objectURL) {
+        getWindow(objectURL).getDocument().revokeBlobUrl(Context.toString(objectURL));
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/dom/Document.java
+++ b/src/main/java/org/htmlunit/javascript/host/dom/Document.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -114,6 +115,7 @@ import org.htmlunit.javascript.host.event.ProgressEvent;
 import org.htmlunit.javascript.host.event.TextEvent;
 import org.htmlunit.javascript.host.event.UIEvent;
 import org.htmlunit.javascript.host.event.WheelEvent;
+import org.htmlunit.javascript.host.file.Blob;
 import org.htmlunit.javascript.host.html.HTMLAllCollection;
 import org.htmlunit.javascript.host.html.HTMLBodyElement;
 import org.htmlunit.javascript.host.html.HTMLCollection;
@@ -220,6 +222,8 @@ public class Document extends Node {
     private ScriptableObject currentScript_;
     private transient FontFaceSet fonts_;
     private transient StyleSheetList styleSheetList_;
+
+    private final Map<String, Blob> blobUrl2Blobs = new HashMap<>();
 
     static {
         // commands
@@ -3471,5 +3475,32 @@ public class Document extends Node {
     @Override
     public boolean contains(final Object element) {
         return getDocumentElement().contains(element);
+    }
+
+    /**
+     * Generate and return the URL for the given blob.
+     * @see org.htmlunit.javascript.host.URL.createObjectURL()
+     */
+    public String generateBlobUrl(final Blob blob) {
+        URL url = getPage().getUrl();
+        String origin = (url == UrlUtils.URL_ABOUT_BLANK) ? "null" : (url.getProtocol() + "://" + url.getAuthority());
+        String blobUrl = "blob:" + origin + "/" + UUID.randomUUID();
+        blobUrl2Blobs.put(blobUrl, blob);
+        return blobUrl;
+    }
+
+    /**
+     * Returns the Blob for the given URL or {@code null} if not found.
+     */
+    public Blob resolveBlobUrl(final String url) {
+        return blobUrl2Blobs.get(url);
+    }
+
+    /**
+     * Revokes the URL for the given blob.
+     * @see org.htmlunit.javascript.host.URL.revokeObjectURL()
+     */
+    public void revokeBlobUrl(final String url) {
+        blobUrl2Blobs.remove(url);
     }
 }

--- a/src/test/java/org/htmlunit/javascript/host/URLTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/URLTest.java
@@ -132,7 +132,6 @@ public class URLTest extends WebDriverTestCase {
      * @throws Exception if the test fails
      */
     @Test
-    @NotYetImplemented
     public void createObjectURL() throws Exception {
         final String html
             = HtmlPageTest.STANDARDS_MODE_PREFIX_


### PR DESCRIPTION
### This PR does the following
- Add simple implementation for [URL.createObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static) and [URL.revokeObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static)