### PR TITLE
Fix unintended behaviors of Location.reload()

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/Location.java
+++ b/src/main/java/org/htmlunit/javascript/host/Location.java
@@ -227,6 +227,8 @@ public class Location extends HtmlUnitScriptable {
         final HtmlPage htmlPage = (HtmlPage) webWindow.getEnclosedPage();
         final WebRequest request = htmlPage.getWebResponse().getWebRequest();
 
+        // update request url with location.href in case hash was changed
+        request.setUrl(new URL(getHref()));
         if (webWindow.getWebClient().getBrowserVersion().hasFeature(JS_LOCATION_RELOAD_REFERRER)) {
             request.setRefererlHeader(htmlPage.getUrl());
         }

--- a/src/main/java/org/htmlunit/javascript/host/Location.java
+++ b/src/main/java/org/htmlunit/javascript/host/Location.java
@@ -53,6 +53,7 @@ import org.htmlunit.util.UrlUtils;
  * @author Frank Danek
  * @author Adam Afeltowicz
  * @author Atsushi Nakagawa
+ * @author Kanoko Yamamoto
  *
  * @see <a href="http://msdn.microsoft.com/en-us/library/ms535866.aspx">MSDN Documentation</a>
  */
@@ -230,7 +231,7 @@ public class Location extends HtmlUnitScriptable {
             request.setRefererlHeader(htmlPage.getUrl());
         }
 
-        webWindow.getWebClient().download(webWindow, "", request, true, false, false, "JS location.reload");
+        webWindow.getWebClient().download(webWindow, "", request, false, false, false, "JS location.reload");
     }
 
     /**

--- a/src/test/java/org/htmlunit/javascript/host/LocationTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/LocationTest.java
@@ -385,11 +385,11 @@ public class LocationTest extends SimpleWebTestCase {
                 "reload",
                 "hash: no hash",
                 "update hash then reload",
-                "hash: no hash", // FIXME: this should be "hash: #0"
+                "hash: #0",
                 "update hash then reload",
-                "hash: no hash", // FIXME: this should be "hash: #1"
+                "hash: #1",
                 "reload",
-                "hash: no hash", // FIXME: this should be "hash: #1"
+                "hash: #1",
         };
         assertEquals(expected, alerts);
     }
@@ -434,9 +434,9 @@ public class LocationTest extends SimpleWebTestCase {
                 "reload",
                 "hash: #0",
                 "update hash then reload",
-                "hash: #0", // FIXME: this should be "hash: #1"
+                "hash: #1",
                 "update hash then reload",
-                "hash: #0", // FIXME: this should be "hash: #2"
+                "hash: #2",
         };
         assertEquals(expected, alerts);
     }

--- a/src/test/java/org/htmlunit/javascript/host/LocationTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/LocationTest.java
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
  * @author Ahmed Ashour
  * @author Ronald Brill
  * @author Lai Quang Duong
+ * @author Kanoko Yamamoto
  */
 @RunWith(BrowserRunner.class)
 public class LocationTest extends SimpleWebTestCase {
@@ -412,30 +413,30 @@ public class LocationTest extends SimpleWebTestCase {
         String date = page.getElementById("date").asNormalizedText();
         page = page.getElementById("reload").click();
         String newDate = page.getElementById("date").asNormalizedText();
-        assertEquals(date, newDate); // FIXME: this should be assertNotEquals
+        assertNotSame(date, newDate);
 
         Thread.sleep(100);
 
         date = newDate;
         page = page.getElementById("updateHashThenReload").click();
         newDate = page.getElementById("date").asNormalizedText();
-        assertEquals(date, newDate); // FIXME: this should be assertNotEquals
+        assertNotSame(date, newDate);
 
         Thread.sleep(100);
 
         date = newDate;
         page = page.getElementById("updateHashThenReload").click();
         newDate = page.getElementById("date").asNormalizedText();
-        assertEquals(date, newDate); // FIXME: this should be assertNotEquals
+        assertNotSame(date, newDate);
 
         String[] expected = {
                 "hash: #0",
                 "reload",
-                // FIXME: missing "hash: #0"
+                "hash: #0",
                 "update hash then reload",
-                // FIXME: missing "hash: #1"
+                "hash: #0", // FIXME: this should be "hash: #1"
                 "update hash then reload",
-                // FIXME: missing "hash: #2"
+                "hash: #0", // FIXME: this should be "hash: #2"
         };
         assertEquals(expected, alerts);
     }

--- a/src/test/java/org/htmlunit/javascript/host/LocationTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/LocationTest.java
@@ -356,29 +356,37 @@ public class LocationTest extends SimpleWebTestCase {
 
         String date = page.getElementById("date").asNormalizedText();
         page = page.getElementById("reload").click();
+
         String newDate = page.getElementById("date").asNormalizedText();
         assertNotSame(date, newDate);
+        assertEquals(url, page.getUrl());
 
         Thread.sleep(100);
 
         date = newDate;
         page = page.getElementById("updateHashThenReload").click();
+
         newDate = page.getElementById("date").asNormalizedText();
         assertNotSame(date, newDate);
+        assertEquals(true, page.getUrl().toString().endsWith("#0"));
 
         Thread.sleep(100);
 
         date = newDate;
         page = page.getElementById("updateHashThenReload").click();
+
         newDate = page.getElementById("date").asNormalizedText();
         assertNotSame(date, newDate);
+        assertEquals(true, page.getUrl().toString().endsWith("#1"));
 
         Thread.sleep(100);
 
         date = newDate;
         page = page.getElementById("reload").click();
+
         newDate = page.getElementById("date").asNormalizedText();
         assertNotSame(date, newDate);
+        assertEquals(true, page.getUrl().toString().endsWith("#1"));
 
         String[] expected = {
                 "hash: no hash",
@@ -412,22 +420,28 @@ public class LocationTest extends SimpleWebTestCase {
 
         String date = page.getElementById("date").asNormalizedText();
         page = page.getElementById("reload").click();
+
         String newDate = page.getElementById("date").asNormalizedText();
         assertNotSame(date, newDate);
+        assertEquals(true, page.getUrl().toString().endsWith("#0"));
 
         Thread.sleep(100);
 
         date = newDate;
         page = page.getElementById("updateHashThenReload").click();
+
         newDate = page.getElementById("date").asNormalizedText();
         assertNotSame(date, newDate);
+        assertEquals(true, page.getUrl().toString().endsWith("#1"));
 
         Thread.sleep(100);
 
         date = newDate;
         page = page.getElementById("updateHashThenReload").click();
+
         newDate = page.getElementById("date").asNormalizedText();
         assertNotSame(date, newDate);
+        assertEquals(true, page.getUrl().toString().endsWith("#2"));
 
         String[] expected = {
                 "hash: #0",

--- a/src/test/resources/org/htmlunit/javascript/host/LocationTest_reload.html
+++ b/src/test/resources/org/htmlunit/javascript/host/LocationTest_reload.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function update() {
+  var hash = location.hash === "" ? "no hash" : location.hash;
+  alert("hash: " + hash);
+  document.getElementById("date").innerText += Date.now();
+  document.getElementById("hash").innerText += hash;
+}
+
+function reload() {
+  alert("reload");
+  location.reload();
+}
+
+function updateHashThenReload() {
+  location.hash = location.hash === "" ? "0" : (parseInt(location.hash.replace("#", "")) + 1);
+  alert("update hash then reload");
+  location.reload();
+}
+</script>
+</head>
+<body onload="update()">
+<span id="date"></span>
+<span id="hash"></span>
+<input id="reload" type="button" value="Reload" onclick="reload()">
+<input id="updateHashThenReload" type="button" value="Update hash then reload" onclick="updateHashThenReload()">
+</body>
+</html>


### PR DESCRIPTION
### This PR does the following
- Make `Location.reload()` behave like real browsers by
  - Fix an issue where calling `reload()` will not actually reload the page if the current href contains a hash, as showed in `LocationTest.reloadWithHash()`
  - Fix an issue where the updated hash value is not preserved after calling `reload()`, as showed in `LocationTest.reloadNoHash()`