### PR TITLE
Support URL.createObjectURL() (continue)

### DIFF
--- a/src/main/java/org/htmlunit/WebClient.java
+++ b/src/main/java/org/htmlunit/WebClient.java
@@ -1404,6 +1404,14 @@ public class WebClient implements Serializable, AutoCloseable {
         if (!StringUtils.isEmpty(type)) {
             headers.add(new NameValuePair(HttpHeader.CONTENT_TYPE, fileOrBlob.getType()));
         }
+        if (fileOrBlob instanceof org.htmlunit.javascript.host.file.File) {
+            final org.htmlunit.javascript.host.file.File file = (org.htmlunit.javascript.host.file.File)fileOrBlob;
+            final String fileName = file.getName();
+            if (!StringUtils.isEmpty(fileName)) {
+                // https://datatracker.ietf.org/doc/html/rfc6266#autoid-10
+                headers.add(new NameValuePair(HttpHeader.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\""));
+            }
+        }
 
         final DownloadedContent content = new DownloadedContent.InMemory(fileOrBlob.getBytes());
         final WebResponseData responseData = new WebResponseData(content, 200, "OK", headers);

--- a/src/main/java/org/htmlunit/WebClient.java
+++ b/src/main/java/org/htmlunit/WebClient.java
@@ -540,7 +540,7 @@ public class WebClient implements Serializable, AutoCloseable {
      */
     public Page loadWebResponseInto(final WebResponse webResponse, final WebWindow webWindow)
         throws IOException, FailingHttpStatusCodeException {
-        return loadWebResponseInto(webResponse, webWindow, false);
+        return loadWebResponseInto(webResponse, webWindow, null);
     }
 
     /**
@@ -556,8 +556,8 @@ public class WebClient implements Serializable, AutoCloseable {
      *
      * @param webResponse the response that will be used to create the new page
      * @param webWindow the window that the new page will be placed within
-     * @param forceAttachment handle this as attachment (is set to true if the call was triggered from
-     * anchor with download property set).
+     * @param forceAttachmentWithFilename if not {@code null}, handle this as an attachment with the specified name or if an empty string ("")
+     * use the filename provided in the response
      * @throws IOException if an IO error occurs
      * @throws FailingHttpStatusCodeException if the server returns a failing status code AND the property
      *         {@link WebClientOptions#setThrowExceptionOnFailingStatusCode(boolean)} is set to true
@@ -565,7 +565,7 @@ public class WebClient implements Serializable, AutoCloseable {
      * @see #setAttachmentHandler(AttachmentHandler)
      */
     public Page loadWebResponseInto(final WebResponse webResponse, final WebWindow webWindow,
-            final boolean forceAttachment)
+            final String forceAttachmentWithFilename)
             throws IOException, FailingHttpStatusCodeException {
         WebAssert.notNull("webResponse", webResponse);
         WebAssert.notNull("webWindow", webWindow);
@@ -580,8 +580,8 @@ public class WebClient implements Serializable, AutoCloseable {
         }
 
         if (attachmentHandler_ != null
-                && (forceAttachment || attachmentHandler_.isAttachment(webResponse))) {
-            if (attachmentHandler_.handleAttachment(webResponse)) {
+                && (forceAttachmentWithFilename != null || attachmentHandler_.isAttachment(webResponse))) {
+            if (attachmentHandler_.handleAttachment(webResponse, StringUtils.isEmpty(forceAttachmentWithFilename) ? null : forceAttachmentWithFilename)) {
                 // the handling is done by the attachment handler;
                 // do not open a new window
                 return webWindow.getEnclosedPage();
@@ -589,7 +589,7 @@ public class WebClient implements Serializable, AutoCloseable {
 
             final WebWindow w = openWindow(null, null, webWindow);
             final Page page = pageCreator_.createPage(webResponse, w);
-            attachmentHandler_.handleAttachment(page);
+            attachmentHandler_.handleAttachment(page, StringUtils.isEmpty(forceAttachmentWithFilename) ? null : forceAttachmentWithFilename);
             return page;
         }
 
@@ -2526,18 +2526,18 @@ public class WebClient implements Serializable, AutoCloseable {
         private final WebResponse response_;
         private final WeakReference<Page> originalPage_;
         private final WebRequest request_;
-        private final boolean forceAttachment_;
+        private final String forceAttachmentWithFilename_;
 
         // we can't us the WebRequest from the WebResponse because
         // we need the original request e.g. after a redirect
         LoadJob(final WebRequest request, final WebResponse response,
-                final WebWindow requestingWindow, final String target, final boolean forceAttachment) {
+                final WebWindow requestingWindow, final String target, final String forceAttachmentWithFilename) {
             request_ = request;
             requestingWindow_ = requestingWindow;
             target_ = target;
             response_ = response;
             originalPage_ = new WeakReference<>(requestingWindow.getEnclosedPage());
-            forceAttachment_ = forceAttachment;
+            forceAttachmentWithFilename_ = forceAttachmentWithFilename;
         }
 
         public boolean isOutdated() {
@@ -2568,13 +2568,13 @@ public class WebClient implements Serializable, AutoCloseable {
      * @param request the request to perform
      * @param checkHash if true check for hashChenage
      * @param forceLoad if true always load the request even if there is already the same in the queue
-     * @param forceAttachment if true the AttachmentHandler isAttachment() method is not called, the
+     * @param forceAttachmentWithFilename if not {@code null} the AttachmentHandler isAttachment() method is not called, the
      * response has to be handled as attachment in any case
      * @param description information about the origin of the request. Useful for debugging.
      */
     public void download(final WebWindow requestingWindow, final String target,
         final WebRequest request, final boolean checkHash, final boolean forceLoad,
-        final boolean forceAttachment, final String description) {
+        final String forceAttachmentWithFilename, final String description) {
 
         final WebWindow targetWindow = resolveWindow(requestingWindow, target);
         final URL url = request.getUrl();
@@ -2631,7 +2631,7 @@ public class WebClient implements Serializable, AutoCloseable {
                 LOG.error("NoHttpResponseException while downloading; generating a NoHttpResponse", e);
                 response = new WebResponse(RESPONSE_DATA_NO_HTTP_RESPONSE, request, 0);
             }
-            loadJob = new LoadJob(request, response, requestingWindow, target, forceAttachment);
+            loadJob = new LoadJob(request, response, requestingWindow, target, forceAttachmentWithFilename);
         }
         catch (final IOException e) {
             throw new RuntimeException(e);
@@ -2683,7 +2683,7 @@ public class WebClient implements Serializable, AutoCloseable {
 
             final WebWindow win = openTargetWindow(loadJob.requestingWindow_, loadJob.target_, TARGET_SELF);
             final Page pageBeforeLoad = win.getEnclosedPage();
-            loadWebResponseInto(loadJob.response_, win, loadJob.forceAttachment_);
+            loadWebResponseInto(loadJob.response_, win, loadJob.forceAttachmentWithFilename_);
 
             // start execution here.
             if (scriptEngine_ != null) {

--- a/src/main/java/org/htmlunit/attachment/Attachment.java
+++ b/src/main/java/org/htmlunit/attachment/Attachment.java
@@ -56,6 +56,10 @@ public class Attachment {
     public String getSuggestedFilename() {
         final WebResponse response = page_.getWebResponse();
         final String disp = response.getResponseHeaderValue(HttpHeader.CONTENT_DISPOSITION);
+        if (disp == null) {
+            return null;
+        }
+
         int start = disp.indexOf("filename=");
         if (start == -1) {
             return null;

--- a/src/main/java/org/htmlunit/attachment/Attachment.java
+++ b/src/main/java/org/htmlunit/attachment/Attachment.java
@@ -32,12 +32,25 @@ public class Attachment {
     /** The attached page. */
     private final Page page_;
 
+    /** The file name of this attachment. */
+    private final String attachmentFilename_;
+
     /**
      * Creates a new attachment for the specified page.
      * @param page the attached page
      */
     public Attachment(final Page page) {
+        this(page, null);
+    }
+
+    /**
+     * Creates a new attachment for the specified page.
+     * @param page the attached page
+     * @param attachmentFilename the file name of this attachment
+     */
+    public Attachment(final Page page, final String attachmentFilename) {
         page_ = page;
+        attachmentFilename_ = attachmentFilename;
     }
 
     /**
@@ -54,6 +67,10 @@ public class Attachment {
      * @return the attachment's suggested filename, or {@code null} if none was suggested
      */
     public String getSuggestedFilename() {
+        if (attachmentFilename_ != null) {
+            return attachmentFilename_;
+        }
+
         final WebResponse response = page_.getWebResponse();
         final String disp = response.getResponseHeaderValue(HttpHeader.CONTENT_DISPOSITION);
         if (disp == null) {

--- a/src/main/java/org/htmlunit/attachment/AttachmentHandler.java
+++ b/src/main/java/org/htmlunit/attachment/AttachmentHandler.java
@@ -54,7 +54,19 @@ public interface AttachmentHandler extends Serializable {
      * has returned false for the response.
      * @param page an attached page, which doesn't get loaded inline
      */
-    void handleAttachment(Page page);
+    default void handleAttachment(Page page) {
+        handleAttachment(page, null);
+    }
+
+    /**
+     * Handles the specified attached page. This is some kind of information
+     * that the page was handled as attachment.
+     * This method will only be called if {@link #handleAttachment(WebResponse)}
+     * has returned false for the response.
+     * @param page an attached page, which doesn't get loaded inline
+     * @param attachmentFilename the filename to use for the attachment or {@code null} if unspecified
+     */
+    void handleAttachment(Page page, final String attachmentFilename);
 
     /**
      * Process the specified attachment. If this method returns false,
@@ -67,6 +79,21 @@ public interface AttachmentHandler extends Serializable {
      * @see <a href="http://www.ietf.org/rfc/rfc2183.txt">RFC 2183</a>
      */
     default boolean handleAttachment(final WebResponse response) {
+        return handleAttachment(response, null);
+    }
+
+    /**
+     * Process the specified attachment. If this method returns false,
+     * the client will open a new window with a page created from this
+     * response as content.
+     * Overwrite this method (and return true) if you do not need to create
+     * a new window for the response.
+     * @param response the response to process
+     * @param attachmentFilename the filename to use for the attachment or {@code null} if unspecified
+     * @return {@code true} if the specified response represents is handled by this method
+     * @see <a href="http://www.ietf.org/rfc/rfc2183.txt">RFC 2183</a>
+     */
+    default boolean handleAttachment(final WebResponse response, final String attachmentFilename) {
         return false;
     }
 

--- a/src/main/java/org/htmlunit/attachment/CollectingAttachmentHandler.java
+++ b/src/main/java/org/htmlunit/attachment/CollectingAttachmentHandler.java
@@ -53,8 +53,8 @@ public class CollectingAttachmentHandler implements AttachmentHandler {
      * {@inheritDoc}
      */
     @Override
-    public void handleAttachment(final Page page) {
-        collectedAttachments_.add(new Attachment(page));
+    public void handleAttachment(final Page page, final String attachmentFilename) {
+        collectedAttachments_.add(new Attachment(page, attachmentFilename));
     }
 
     /**

--- a/src/main/java/org/htmlunit/html/HtmlAnchor.java
+++ b/src/main/java/org/htmlunit/html/HtmlAnchor.java
@@ -113,6 +113,7 @@ public class HtmlAnchor extends HtmlElement {
         if (ATTRIBUTE_NOT_DEFINED == getHrefAttribute()) {
             return;
         }
+        final String downloadAttribute = getDownloadAttribute();
         HtmlPage page = (HtmlPage) getPage();
         if (StringUtils.startsWithIgnoreCase(href, JavaScriptURLConnection.JAVASCRIPT_PREFIX)) {
             final StringBuilder builder = new StringBuilder(href.length());
@@ -133,7 +134,7 @@ public class HtmlAnchor extends HtmlElement {
             }
 
             final String target;
-            if (shiftKey || ctrlKey || ATTRIBUTE_NOT_DEFINED != getDownloadAttribute()) {
+            if (shiftKey || ctrlKey || ATTRIBUTE_NOT_DEFINED != downloadAttribute) {
                 target = WebClient.TARGET_BLANK;
             }
             else {
@@ -186,14 +187,14 @@ public class HtmlAnchor extends HtmlElement {
         final String target;
         if (shiftKey || ctrlKey
                 || (webClient.getAttachmentHandler() == null
-                        && ATTRIBUTE_NOT_DEFINED != getDownloadAttribute())) {
+                        && ATTRIBUTE_NOT_DEFINED != downloadAttribute)) {
             target = WebClient.TARGET_BLANK;
         }
         else {
             target = page.getResolvedTarget(getTargetAttribute());
         }
         page.getWebClient().download(page.getEnclosingWindow(), target, webRequest,
-                true, false, ATTRIBUTE_NOT_DEFINED != getDownloadAttribute(), "Link click");
+                true, false, (ATTRIBUTE_NOT_DEFINED != downloadAttribute) ? downloadAttribute : null, "Link click");
     }
 
     private boolean relContainsNoreferrer() {

--- a/src/main/java/org/htmlunit/html/HtmlForm.java
+++ b/src/main/java/org/htmlunit/html/HtmlForm.java
@@ -190,7 +190,7 @@ public class HtmlForm extends HtmlElement {
 
         final WebWindow webWindow = htmlPage.getEnclosingWindow();
         // Calling form.submit() twice forces double download.
-        webClient.download(webWindow, target, request, false, false, false, "JS form.submit()");
+        webClient.download(webWindow, target, request, false, false, null, "JS form.submit()");
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/Location.java
+++ b/src/main/java/org/htmlunit/javascript/host/Location.java
@@ -234,7 +234,7 @@ public class Location extends HtmlUnitScriptable {
             request.setRefererlHeader(htmlPage.getUrl());
         }
 
-        webWindow.getWebClient().download(webWindow, "", request, false, false, false, "JS location.reload");
+        webWindow.getWebClient().download(webWindow, "", request, false, false, null, "JS location.reload");
     }
 
     /**
@@ -320,7 +320,7 @@ public class Location extends HtmlUnitScriptable {
             request.setRefererlHeader(page.getUrl());
 
             webWindow = window_.getWebWindow();
-            webWindow.getWebClient().download(webWindow, "", request, true, false, false, "JS set location");
+            webWindow.getWebClient().download(webWindow, "", request, true, false, null, "JS set location");
         }
         catch (final MalformedURLException e) {
             if (LOG.isErrorEnabled()) {

--- a/src/test/java/org/htmlunit/attachment/AttachmentTest.java
+++ b/src/test/java/org/htmlunit/attachment/AttachmentTest.java
@@ -180,6 +180,37 @@ public class AttachmentTest extends SimpleWebTestCase {
     }
 
     /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void filenameFromAnchor() throws Exception {
+        final WebClient client = getWebClient();
+        final MockWebConnection conn = new MockWebConnection();
+        client.setWebConnection(conn);
+        final List<Attachment> attachments = new ArrayList<>();
+        client.setAttachmentHandler(new CollectingAttachmentHandler(attachments));
+
+        final String content = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + "var blob = new Blob(['foo'], {type: 'text/plain'}),\n"
+                + "  url = URL.createObjectURL(blob),\n"
+                + "  elem = document.createElement('a');\n"
+                + "elem.href = url, elem.download = 'foo.txt', elem.click();\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "</html>\n";
+
+        conn.setResponse(URL_FIRST, content);
+        client.getPage(URL_FIRST);
+
+        final Attachment result = attachments.get(0);
+        assertEquals(result.getSuggestedFilename(), "foo.txt");
+        assertEquals("foo", ((TextPage) result.getPage()).getContent());
+        attachments.clear();
+    }
+
+    /**
      * This was causing a ClassCastException in Location.setHref as of 2013-10-08 because the TextPage
      * used for the attachment was wrongly associated to the HTMLDocument of the first page.
      * @throws Exception if an error occurs

--- a/src/test/java/org/htmlunit/attachment/AttachmentTest.java
+++ b/src/test/java/org/htmlunit/attachment/AttachmentTest.java
@@ -238,7 +238,7 @@ public class AttachmentTest extends SimpleWebTestCase {
             }
 
             @Override
-            public void handleAttachment(final Page page) {
+            public void handleAttachment(final Page page, final String attachmentFilename) {
                 throw new IllegalAccessError("handleAttachment(Page) called");
             }
         });

--- a/src/test/java/org/htmlunit/html/HtmlAnchor2Test.java
+++ b/src/test/java/org/htmlunit/html/HtmlAnchor2Test.java
@@ -911,7 +911,7 @@ public class HtmlAnchor2Test extends SimpleWebTestCase {
         getWebClient().setAttachmentHandler(new AttachmentHandler() {
 
             @Override
-            public void handleAttachment(final Page page) {
+            public void handleAttachment(final Page page, final String attachmentFilename) {
                 pages.add(page);
             }
         });
@@ -957,7 +957,7 @@ public class HtmlAnchor2Test extends SimpleWebTestCase {
             }
 
             @Override
-            public void handleAttachment(final Page page) {
+            public void handleAttachment(final Page page, final String attachmentFilename) {
                 pages.add(page);
             }
         });
@@ -1002,7 +1002,7 @@ public class HtmlAnchor2Test extends SimpleWebTestCase {
             }
 
             @Override
-            public void handleAttachment(final Page page) {
+            public void handleAttachment(final Page page, final String attachmentFilename) {
                 throw new IllegalAccessError("handleAttachment(Page) called");
             }
         });
@@ -1052,7 +1052,7 @@ public class HtmlAnchor2Test extends SimpleWebTestCase {
             }
 
             @Override
-            public void handleAttachment(final Page page) {
+            public void handleAttachment(final Page page, final String attachmentFilename) {
                 throw new IllegalAccessError("handleAttachment(Page) called");
             }
         });
@@ -1113,7 +1113,7 @@ public class HtmlAnchor2Test extends SimpleWebTestCase {
         final LinkedList<Page> pages = new LinkedList<>();
         getWebClient().setAttachmentHandler(new AttachmentHandler() {
             @Override
-            public void handleAttachment(final Page page) {
+            public void handleAttachment(final Page page, final String attachmentFilename) {
                 pages.add(page);
             }
         });
@@ -1159,7 +1159,7 @@ public class HtmlAnchor2Test extends SimpleWebTestCase {
             }
 
             @Override
-            public void handleAttachment(final Page page) {
+            public void handleAttachment(final Page page, final String attachmentFilename) {
                 throw new IllegalAccessError("handleAttachment(Page) called");
             }
         });


### PR DESCRIPTION
### This PR does the following
- Improve `Attachment.getSuggestedFilename()` by making it
  - prioritize the value of [Anchor.download](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download) if exist.
  - return the value of `File.name` if the attachment was downloaded through a blob-url created from a `File`.