### PR TITLE
Fixes to HtmlElement.type(), IFrame local resources and XMLHttpRequest

### DIFF
--- a/src/main/java/org/htmlunit/html/BaseFrameElement.java
+++ b/src/main/java/org/htmlunit/html/BaseFrameElement.java
@@ -190,6 +190,12 @@ public abstract class BaseFrameElement extends HtmlElement {
                 return;
             }
 
+            // accessing to local resource is forbidden for security reason
+            if (url.getProtocol().equals("file")) {
+                notifyIncorrectness("Not allowed to load local resource: " + source);
+                return;
+            }
+
             final Charset pageCharset = page.getCharset();
             final URL pageUrl = page.getUrl();
             final WebRequest request = new WebRequest(url, pageCharset, pageUrl);

--- a/src/main/java/org/htmlunit/html/HtmlElement.java
+++ b/src/main/java/org/htmlunit/html/HtmlElement.java
@@ -843,7 +843,7 @@ public abstract class HtmlElement extends DomElement {
     protected boolean acceptChar(final char c) {
         // This range is this is private use area
         // see http://www.unicode.org/charts/PDF/UE000.pdf
-        return (c < '\uE000' || c > '\uF8FF') && (c == ' ' || !Character.isWhitespace(c));
+        return (c < '\uE000' || c > '\uF8FF') && (c == ' ' || c == '\t' || c == '\u3000' || c == '\u2006' || !Character.isWhitespace(c));
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
@@ -883,6 +883,16 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
      * The real send job.
      */
     void doSend() {
+        if (webRequest_.getUrl().getProtocol().equals("file")) {
+            // accessing to local resource is forbidden for security reason
+            setState(DONE);
+            fireJavascriptEvent(Event.TYPE_READY_STATE_CHANGE);
+            fireJavascriptEvent(Event.TYPE_ERROR);
+            fireJavascriptEvent(Event.TYPE_LOAD_END);
+            throw JavaScriptEngine.throwAsScriptRuntimeEx(
+                    new RuntimeException("Not allowed to load local resource: " + webRequest_.getUrl()));
+        }
+
         final BrowserVersion browserVersion = getBrowserVersion();
         final WebClient wc = getWindow().getWebWindow().getWebClient();
         boolean preflighted = false;

--- a/src/test/java/org/htmlunit/html/HtmlElementTest.java
+++ b/src/test/java/org/htmlunit/html/HtmlElementTest.java
@@ -1224,4 +1224,14 @@ public class HtmlElementTest extends SimpleWebTestCase {
             assertEquals(Boolean.parseBoolean(getExpectedAlerts()[2]), page.getElementById("d3").isDisplayed());
         }
     }
+
+    @Test
+    public void acceptChar() throws Exception {
+        final String html = "<html><body><input></body></html>";
+        final HtmlPage page = loadPage(html);
+        final String value = "abc[ ][\t][　][\u2006]123あいう漢字[!@#$%^&*()-=_+]{}<>?/\\";
+        HtmlInput input = page.getFirstByXPath("//input");
+        input.type(value);
+        assertEquals(value, input.getValue());
+    }
 }


### PR DESCRIPTION
### This PR does the following
- Make HtmlUnit behave more like real browsers by
  - make `HtmlElement.type()` allow `full-width space (\u3000)`, `six-per-em space (\u2006)` and `tab (\t)` characters
  - prevent `Iframe` & `XMLHttpRequest` from loading local resource for security reason
  ~~- add missing property keys `response` and `responseType` to `XMLHttpRequest`~~