### PR TITLE
Add downloading file attachment handler

### DIFF
--- a/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
+++ b/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
@@ -7,10 +7,14 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.htmlunit.Page;
+import org.htmlunit.WebResponseData;
 
 public class DownloadingAttachmentHandler implements AttachmentHandler {
 
+    private static final Log LOG = LogFactory.getLog(DownloadingAttachmentHandler.class);
 	private Path downloadFolder;
 
 	public DownloadingAttachmentHandler(Path downloadFolder) throws IOException {
@@ -30,7 +34,7 @@ public class DownloadingAttachmentHandler implements AttachmentHandler {
 		try {
 			contentAsStream = page.getWebResponse().getContentAsStream();
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOG.error("Failed to get attachment response content as stream");
 			return;
 		}
 		try {
@@ -39,15 +43,18 @@ public class DownloadingAttachmentHandler implements AttachmentHandler {
 			try {
 				Files.copy(contentAsStream, findNextAvailableFilename(attachmentFilename));
 			} catch (IOException e1) {
-				e1.printStackTrace();
+				logFailureToSaveAttachment();
 				return;
 			}
 		} catch (IOException e) {
-			System.out.println("something wrong happened");
-			e.printStackTrace();
+			logFailureToSaveAttachment();
 			return;
 		}
 		page.getWebResponse().cleanUp();
+	}
+
+	private void logFailureToSaveAttachment() {
+		LOG.error("Failed to write attachment response to ".concat(downloadFolder.toString()));
 	}
 
 	private String getFilenameFromUrlIfEmpty(Page page, String attachmentFilename) {

--- a/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
+++ b/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
@@ -1,0 +1,78 @@
+package org.htmlunit.attachment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+import org.htmlunit.Page;
+
+public class DownloadingAttachmentHandler implements AttachmentHandler {
+
+	private Path downloadFolder;
+
+	public DownloadingAttachmentHandler(Path downloadFolder) {
+		this.downloadFolder = downloadFolder;
+//		TODO throwing unchecked exception seems like a bad idea, wait for feedback from Ronald
+		if (!Files.isWritable(downloadFolder)) throw new RuntimeException("Can't write to ".concat(downloadFolder.toString()));
+	}
+
+	public DownloadingAttachmentHandler() {
+		this(Path.of(System.getProperty("java.io.tmpdir")));
+	}
+	
+	@Override
+	public void handleAttachment(Page page, String attachmentFilename) {
+		attachmentFilename = getFilenameFromUrlIfEmpty(page, attachmentFilename);
+		Path downloadDestinationFilePath = downloadFolder.resolve(attachmentFilename);
+		InputStream contentAsStream;
+		try {
+			contentAsStream = page.getWebResponse().getContentAsStream();
+		} catch (IOException e) {
+//			TODO throw exception?
+			e.printStackTrace();
+			return;
+		}
+		try {
+			Files.copy(contentAsStream, downloadDestinationFilePath);
+		} catch (FileAlreadyExistsException e) {
+			try {
+				Files.copy(contentAsStream, findNextAvailableFilename(attachmentFilename));
+			} catch (IOException e1) {
+//				TODO throw exception?
+				e1.printStackTrace();
+				return;
+			}
+		} catch (IOException e) {
+//			TODO throw exception?
+			System.out.println("something wrong happened");
+			e.printStackTrace();
+			return;
+		}
+		page.getWebResponse().cleanUp();
+
+		System.out.println("Handling attahcment");
+	}
+
+	private String getFilenameFromUrlIfEmpty(Page page, String attachmentFilename) {
+		if (attachmentFilename==null) {
+			String file = page.getWebResponse().getWebRequest().getUrl().getFile();
+			attachmentFilename = file.substring(file.lastIndexOf('/') + 1);
+		}
+		return attachmentFilename;
+	}
+
+	private Path findNextAvailableFilename(String fileName) {
+		Path newPath;
+		Integer count = 0;
+		do  {
+			count++;
+		int fileExtensionstartPosition = (fileName.contains(".") ) ? fileName.lastIndexOf('.') : fileName.length() ;
+		newPath = downloadFolder.resolve(fileName.substring(0, fileExtensionstartPosition).concat(" (" + count + ")").concat(fileName.substring(fileExtensionstartPosition)));
+		} while (Files.exists(newPath, LinkOption.NOFOLLOW_LINKS));
+		return newPath;
+	}
+
+}

--- a/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
+++ b/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
@@ -13,13 +13,12 @@ public class DownloadingAttachmentHandler implements AttachmentHandler {
 
 	private Path downloadFolder;
 
-	public DownloadingAttachmentHandler(Path downloadFolder) {
+	public DownloadingAttachmentHandler(Path downloadFolder) throws IOException {
 		this.downloadFolder = downloadFolder;
-//		TODO throwing unchecked exception seems like a bad idea, wait for feedback from Ronald
-		if (!Files.isWritable(downloadFolder)) throw new RuntimeException("Can't write to ".concat(downloadFolder.toString()));
+		if (!Files.isWritable(downloadFolder)) throw new IOException("Can't write to ".concat(downloadFolder.toString()));
 	}
 
-	public DownloadingAttachmentHandler() {
+	public DownloadingAttachmentHandler() throws IOException {
 		this(Path.of(System.getProperty("java.io.tmpdir")));
 	}
 	
@@ -31,7 +30,6 @@ public class DownloadingAttachmentHandler implements AttachmentHandler {
 		try {
 			contentAsStream = page.getWebResponse().getContentAsStream();
 		} catch (IOException e) {
-//			TODO throw exception?
 			e.printStackTrace();
 			return;
 		}
@@ -41,19 +39,15 @@ public class DownloadingAttachmentHandler implements AttachmentHandler {
 			try {
 				Files.copy(contentAsStream, findNextAvailableFilename(attachmentFilename));
 			} catch (IOException e1) {
-//				TODO throw exception?
 				e1.printStackTrace();
 				return;
 			}
 		} catch (IOException e) {
-//			TODO throw exception?
 			System.out.println("something wrong happened");
 			e.printStackTrace();
 			return;
 		}
 		page.getWebResponse().cleanUp();
-
-		System.out.println("Handling attahcment");
 	}
 
 	private String getFilenameFromUrlIfEmpty(Page page, String attachmentFilename) {

--- a/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
+++ b/src/main/java/org/htmlunit/attachment/DownloadingAttachmentHandler.java
@@ -57,7 +57,7 @@ public class DownloadingAttachmentHandler implements AttachmentHandler {
 	}
 
 	private String getFilenameFromUrlIfEmpty(Page page, String attachmentFilename) {
-		if (attachmentFilename==null) {
+		if (attachmentFilename==null || attachmentFilename.trim().isEmpty()) {
 			String file = page.getWebResponse().getWebRequest().getUrl().getFile();
 			attachmentFilename = file.substring(file.lastIndexOf('/') + 1);
 		}

--- a/src/test/java/org/htmlunit/attachment/DownloadingAttachmentHandlerTest.java
+++ b/src/test/java/org/htmlunit/attachment/DownloadingAttachmentHandlerTest.java
@@ -2,6 +2,7 @@ package org.htmlunit.attachment;
 
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
@@ -12,36 +13,37 @@ import org.htmlunit.WebClient;
 import org.htmlunit.html.HtmlAnchor;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.junit.BrowserRunner;
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-//@RunWith(BrowserRunner.class)
 public class DownloadingAttachmentHandlerTest {
 
-	@Test
-	public void test() throws FailingHttpStatusCodeException, MalformedURLException, IOException, InterruptedException {
-		System.out.println(System.getProperty("java.io.tmpdir"));
-		WebClient webClient = new WebClient(BrowserVersion.FIREFOX);
-		webClient.setAttachmentHandler(new DownloadingAttachmentHandler());
-//		HtmlPage page = webClient.getPage("https://github.com/HtmlUnit/htmlunit/releases");
-//		page.getAnchorByText("htmlunit-4.1.0-javadoc.jar.asc").click();
-		HtmlPage page = webClient.getPage("https://www.ghisler.com/download.htm");
-		HtmlAnchor anchorByHref = page.getAnchorByHref("https://totalcommander.ch/1103/tcmd1103x32_64.exe");
-//		HtmlPage page = webClient.getPage("https://www.ronsplace.ca/products/ronsdataedit/download");
-//		HtmlAnchor anchorByHref = page.getAnchorByHref("/contentproduct/data-edit/setup.exe");
-		System.out.println(anchorByHref.asXml());
-		anchorByHref.click();
-		
-		Thread.sleep(100000);
-		
-//		Path.of(System.getProperty("java.io.tmpdir")
-		
-	}
-	
-//	TODO test downloading a file that is an octet stream
-//	TODO test downloading a file that has content disposition and proper attachment header
-//	TODO test downloading a file that does not have an extension (no dot in filename)
-//	TODO test constructor failing if the download folder does not exist or user does not have write access
+	private static final String FILENAME_WITHOUT_EXTENSION = "fileNoDot";
+	private static final String FILENAME_WITH_EXTENSION = "file1.txt";
+	@Rule
+	public File downloadFolder = new TemporaryFolder().getRoot();
 
+	@Test
+	public void whenDownloadFolderWriteable_downloadAttachment() throws IOException {
+		DownloadingAttachmentHandler downloadingAttachmentHandler = new DownloadingAttachmentHandler(
+				downloadFolder.toPath());
+//		TODO add html page with attachment response that is using content disposition
+//		TODO add html page with attachment response that is using octet stream
+//		new HtmlPage().
+		downloadingAttachmentHandler.handleAttachment(null, FILENAME_WITH_EXTENSION);
+		Assert.assertTrue(new File(downloadFolder, FILENAME_WITH_EXTENSION).exists());
+		downloadingAttachmentHandler.handleAttachment(null, FILENAME_WITHOUT_EXTENSION);
+		Assert.assertTrue(new File(downloadFolder, FILENAME_WITHOUT_EXTENSION).exists());
+	}
+
+	@Test
+	public void whenDownloadFolderDoesNotExit_throwException() {
+		Assert.assertThrows(IOException.class, () -> {
+			new DownloadingAttachmentHandler(downloadFolder.toPath().resolve("nonExistentFolder"));
+		});
+	}
 
 }

--- a/src/test/java/org/htmlunit/attachment/DownloadingAttachmentHandlerTest.java
+++ b/src/test/java/org/htmlunit/attachment/DownloadingAttachmentHandlerTest.java
@@ -1,0 +1,47 @@
+package org.htmlunit.attachment;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlAnchor;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.junit.BrowserRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+//@RunWith(BrowserRunner.class)
+public class DownloadingAttachmentHandlerTest {
+
+	@Test
+	public void test() throws FailingHttpStatusCodeException, MalformedURLException, IOException, InterruptedException {
+		System.out.println(System.getProperty("java.io.tmpdir"));
+		WebClient webClient = new WebClient(BrowserVersion.FIREFOX);
+		webClient.setAttachmentHandler(new DownloadingAttachmentHandler());
+//		HtmlPage page = webClient.getPage("https://github.com/HtmlUnit/htmlunit/releases");
+//		page.getAnchorByText("htmlunit-4.1.0-javadoc.jar.asc").click();
+		HtmlPage page = webClient.getPage("https://www.ghisler.com/download.htm");
+		HtmlAnchor anchorByHref = page.getAnchorByHref("https://totalcommander.ch/1103/tcmd1103x32_64.exe");
+//		HtmlPage page = webClient.getPage("https://www.ronsplace.ca/products/ronsdataedit/download");
+//		HtmlAnchor anchorByHref = page.getAnchorByHref("/contentproduct/data-edit/setup.exe");
+		System.out.println(anchorByHref.asXml());
+		anchorByHref.click();
+		
+		Thread.sleep(100000);
+		
+//		Path.of(System.getProperty("java.io.tmpdir")
+		
+	}
+	
+//	TODO test downloading a file that is an octet stream
+//	TODO test downloading a file that has content disposition and proper attachment header
+//	TODO test downloading a file that does not have an extension (no dot in filename)
+//	TODO test constructor failing if the download folder does not exist or user does not have write access
+
+
+}


### PR DESCRIPTION
First draft of an attachment handler that mimics how browsers handle attachments, specifically
- download file into a default folder when attachment response is detected
- infer filename from octet stream response and use that when saving file
- if a file already exists, append number to it. keep incrementing number until you find a slot that is free (thats how Chrome handles duplicate filenames)

The implementation allows defining the download folder. If empty constructor is used, temporary folder is used by default.

Open questions for Ronald
- how should I handle exceptions? 
  - When the download folder can't be used, throw an exception, and if so which one? A silent error would not be useful, but don't want to crash the whole driver
  - When the handle attachment method fails, either due to i/o exception or something else, which exceptions, if any, should be thrown? or should the method eat up the exception and only report and error in the logs?
- What about the test cases, how do you recommend mocking the features?
  - I've added todo notes in my "test" that is really just a method I used to run the thing. The test scenarios I would like to cover are mentioned there, but I have experience with Junit 5 only. Would use a temp dir to test, but if you want to remove any i/o in tests then another option would be to set up mocks.

In general, treat this as a draft as the code is not very clean, but looking for your opinion before refactoring.