### PR TITLE
add listener that silences obsolete content type javascript error

### DIFF
--- a/src/main/java/org/htmlunit/SilentIncorrectnessListener.java
+++ b/src/main/java/org/htmlunit/SilentIncorrectnessListener.java
@@ -1,0 +1,9 @@
+package org.htmlunit;
+
+public class SilentIncorrectnessListener implements IncorrectnessListener {
+
+	@Override
+	public void notify(String message, Object origin) {
+	}
+
+}


### PR DESCRIPTION
Other error handles (css error handler, javascript error handler) have no operation classes that disable messages that can flood logs.

Adding one that was missed for when an obsolete content type is detected