### PR TITLE
Small cleanups

### DIFF
--- a/src/main/java/org/htmlunit/javascript/DebugFrameImpl.java
+++ b/src/main/java/org/htmlunit/javascript/DebugFrameImpl.java
@@ -142,22 +142,16 @@ public class DebugFrameImpl extends DebugFrameAdapter {
         if (LOG.isTraceEnabled()) {
             if (t instanceof JavaScriptException) {
                 final JavaScriptException e = (JavaScriptException) t;
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx)
-                        + " Exception thrown: " + JavaScriptEngine.toString(e.details()));
-                }
+                LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx)
+                    + " Exception thrown: " + JavaScriptEngine.toString(e.details()));
             }
             else if (t instanceof EcmaError) {
                 final EcmaError e = (EcmaError) t;
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx)
-                        + " Exception thrown: " + JavaScriptEngine.toString(e.details()));
-                }
+                LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx)
+                    + " Exception thrown: " + JavaScriptEngine.toString(e.details()));
             }
             else {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx) + " Exception thrown: " + t.getCause());
-                }
+                LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx) + " Exception thrown: " + t.getCause());
             }
         }
     }

--- a/src/main/java/org/htmlunit/javascript/DebugFrameImpl.java
+++ b/src/main/java/org/htmlunit/javascript/DebugFrameImpl.java
@@ -143,12 +143,12 @@ public class DebugFrameImpl extends DebugFrameAdapter {
             if (t instanceof JavaScriptException) {
                 final JavaScriptException e = (JavaScriptException) t;
                 LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx)
-                    + " Exception thrown: " + JavaScriptEngine.toString(e.details()));
+                    + " Exception thrown: " + e.details());
             }
             else if (t instanceof EcmaError) {
                 final EcmaError e = (EcmaError) t;
                 LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx)
-                    + " Exception thrown: " + JavaScriptEngine.toString(e.details()));
+                    + " Exception thrown: " + e.details());
             }
             else {
                 LOG.trace(getSourceName(cx) + ":" + getFirstLine(cx) + " Exception thrown: " + t.getCause());


### PR DESCRIPTION
* No need to check twice for LOG.isTraceEnabled(
* No need to convert a native Java string to a Java string