### PR TITLE
Combine query with request body parameters

### DIFF
--- a/src/main/java/org/htmlunit/WebRequest.java
+++ b/src/main/java/org/htmlunit/WebRequest.java
@@ -367,7 +367,11 @@ public class WebRequest implements Serializable {
                 return normalize(getRequestParameters());
             }
 
-            return normalize(HttpUtils.parseUrlQuery(getRequestBody(), getCharset()));
+            // getRequestParameters and getRequestBody are mutually exclusive
+            final List<NameValuePair> allParameters = new ArrayList<>();
+            allParameters.addAll(HttpUtils.parseUrlQuery(getUrl().getQuery(), getCharset()));
+            allParameters.addAll(HttpUtils.parseUrlQuery(getRequestBody(), getCharset()));
+            return normalize(allParameters);
         }
 
         if (getEncodingType() == FormEncodingType.TEXT_PLAIN  && HttpMethod.POST == getHttpMethod()) {
@@ -379,7 +383,10 @@ public class WebRequest implements Serializable {
         }
 
         if (FormEncodingType.MULTIPART == getEncodingType()) {
-            return normalize(getRequestParameters());
+            final List<NameValuePair> allParameters = new ArrayList<>();
+            allParameters.addAll(HttpUtils.parseUrlQuery(getUrl().getQuery(), getCharset()));
+            allParameters.addAll(getRequestParameters());
+            return normalize(allParameters);
         }
 
         // for instance a PUT or PATCH request

--- a/src/test/java/org/htmlunit/WebRequestTest.java
+++ b/src/test/java/org/htmlunit/WebRequestTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.http.auth.BasicUserPrincipal;
@@ -392,6 +393,43 @@ public class WebRequestTest {
         assertEquals(1, request.getParameters().size());
         assertEquals("x", request.getParameters().get(0).getName());
         assertEquals("u", request.getParameters().get(0).getValue());
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void getParametersFromQueryAndUrlEncodedBodyPost() throws Exception {
+        final URL url = new URL("http://localhost/test?a=b");
+        final WebRequest request = new WebRequest(url);
+        request.setHttpMethod(HttpMethod.POST);
+        request.setEncodingType(FormEncodingType.URL_ENCODED);
+        request.setRequestBody("c=d");
+
+        final List<NameValuePair> parameters = request.getParameters();
+
+        assertEquals(2, parameters.size());
+        assertEquals("a", parameters.get(0).getName());
+        assertEquals("b", parameters.get(0).getValue());
+        assertEquals("c", parameters.get(1).getName());
+        assertEquals("d", parameters.get(1).getValue());
+    }
+
+    @Test
+    public void getParametersFromQueryAndUrlEncodedBodyPostWhenEncodingTypeIsMultipart() throws Exception {
+        final URL url = new URL("http://localhost/test?a=b");
+        final WebRequest request = new WebRequest(url);
+        request.setHttpMethod(HttpMethod.POST);
+        request.setEncodingType(FormEncodingType.MULTIPART);
+        request.setRequestParameters(Collections.singletonList(new NameValuePair("c", "d")));
+
+        final List<NameValuePair> parameters = request.getParameters();
+
+        assertEquals(2, parameters.size());
+        assertEquals("a", parameters.get(0).getName());
+        assertEquals("b", parameters.get(0).getValue());
+        assertEquals("c", parameters.get(1).getName());
+        assertEquals("d", parameters.get(1).getValue());
     }
 
     /**


### PR DESCRIPTION
This way the return value of `org.htmlunit.WebRequest.getParameters` will better resemble that of a servlet api.

Fixes spring-projects/spring-framework#33249
