### PR TITLE
Failing atob test case for malformed input

### DIFF
--- a/src/test/java/org/htmlunit/javascript/host/Window2Test.java
+++ b/src/test/java/org/htmlunit/javascript/host/Window2Test.java
@@ -185,6 +185,24 @@ public class Window2Test extends WebDriverTestCase {
      * @throws Exception if the test fails
      */
     @Test
+    @Alerts({"InvalidCharacterError/DOMException"})
+    public void atobMalformedInput() throws Exception {
+        final String html
+            = "<html><head></head><body>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  try {\n"
+            + "    window.atob('b');\n"
+            + "  } catch(e) {logEx(e)}\n"
+            + "</script>\n"
+            + "</body></html>";
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
     @Alerts({"InvalidCharacterError/DOMException", "InvalidCharacterError/DOMException"})
     public void atobUnicode() throws Exception {
         final String html


### PR DESCRIPTION
Upgrading org.seleniumhq.selenium:htmlunit3-driver to v4.28.0 fails a local project. The change set points to an upgrade of htmlunit from 4.7.0 to 4.9.0. Included in this change set is a switch (7a3c32b354eaf9a90) to java.util.Base64. I suspect that switch comes with a subtle change in an edge case with invalid input.

This change adds a failing test case with an expectation for a InvalidCharacterError as documented in https://developer.mozilla.org/en-US/docs/Web/API/Window/atob.

I have not implemented a fix as to first confirm my understanding.