### PR TITLE
Add basic support for parsing multipart/form-data fetch responses

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,6 +8,9 @@
 
     <body>
         <release version="4.18.0" date="November xx, 2025" description="Chrome/Edge 141, Firefox 144, FirefoxESR 140, Bugfixes">
+            <action type="add" dev="das7pad">
+                Add basic support for parsing multipart/form-data fetch responses
+            </action>
             <action type="fix" dev="rbri">
                 evaluation of the proxy autoconf javascript code fixed (regression)
             </action>

--- a/src/main/resources/org/htmlunit/javascript/polyfill/fetch/.editorconfig
+++ b/src/main/resources/org/htmlunit/javascript/polyfill/fetch/.editorconfig
@@ -1,0 +1,2 @@
+[fetch.umd.js]
+indent_size = 2

--- a/src/main/resources/org/htmlunit/javascript/polyfill/fetch/LICENSE
+++ b/src/main/resources/org/htmlunit/javascript/polyfill/fetch/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2014-2016 GitHub, Inc.
+Copyright (c) 2025 Jakob Ackermann <das7pad@outlook.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/src/test/java/org/htmlunit/javascript/host/fetch/FetchTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/fetch/FetchTest.java
@@ -511,6 +511,45 @@ public class FetchTest extends WebDriverTestCase {
     @Test
     @Disabled
     @Alerts({"200", "OK", "true"})
+    public void fetchMultipartFormData() throws Exception {
+        final String html = DOCTYPE_HTML
+                + "<html>\n"
+                + "  <body>\n"
+                + "    <script>\n"
+                + LOG_TITLE_FUNCTION_NORMALIZE
+                + "      fetch('" + URL_SECOND + "')"
+                + "        .then(response => {\n"
+                + "          log(response.status);\n"
+                + "          log(response.statusText);\n"
+                + "          log(response.ok);\n"
+                + "         })\n"
+                + "        .then(response => {\n"
+                + "          return response.formData();\n"
+                + "        })\n"
+                + "        .then(formData => {\n"
+                + "            log(formData.get('test0'));\n"
+                + "            log(formData.get('test1'));\n"
+                + "        })\n"
+                + "        .catch(e => logEx(e));\n"
+                + "    </script>\n"
+                + "  </body>\n"
+                + "</html>";
+
+        final String content = "--0123456789\r\nContent-Disposition: form-data;name=test0\r\nContent-Type: text/plain\r\nHello1\nHello1\r\n--0123456789\r\nContent-Disposition: form-data;name=test1\r\nContent-Type: text/plain\r\nHello2\nHello2\r\n--0123456789--";
+        getMockWebConnection().setResponse(URL_SECOND, content, "multipart/form-data; boundary=0123456789");
+
+        final WebDriver driver = loadPage2(html);
+        verifyTitle2(DEFAULT_WAIT_TIME, driver, getExpectedAlerts());
+
+        assertEquals(URL_SECOND, getMockWebConnection().getLastWebRequest().getUrl());
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Disabled
+    @Alerts({"200", "OK", "true"})
     public void fetchPostURLSearchParams() throws Exception {
         final String html = DOCTYPE_HTML
             + "<html>\n"


### PR DESCRIPTION
Hi!

For https://github.com/jenkinsci/jenkins/pull/11177 we need basic support for `multipart/form-data` responses. I would like to contribute a simple implementation for it. It only handles the happy path well. Based on https://github.com/mozilla/rhino/issues/1941, I take that a proper Fetch API implementation is planned for the long-term.

Testing:
- Copy and paste the contents of `src/main/resources/org/htmlunit/javascript/polyfill/fetch/fetch.umd.js` into the dev-tools of a browser
- Parse the sample `multipart/form-data` response from the tests

```js
r=new window.WHATWGFetch.Response(
  "--0123456789\r\nContent-Disposition: form-data;name=test0\r\nContent-Type: text/plain\r\n\r\nHello1\nHello1\r\n--0123456789\r\nContent-Disposition: form-data;name=test1\r\nContent-Type: text/plain\r\n\r\nHello2\nHello2\r\n--0123456789--",
  { headers: { 'Content-Type': "multipart/form-data; boundary=0123456789"} }
);
f=await r.formData();
console.assert(f.get('test0') === 'Hello1\nHello1');
console.assert(f.get('test1') === 'Hello2\nHello2');
console.log(Object.fromEntries(Array.from(f.entries())));
``` 
It asserts that the two parts are properly parsed and prints them: 
```js
{test0: 'Hello1\nHello1', test1: 'Hello2\nHello2'}
```