### PR TITLE
Fix a bug where cookies with Max-Age too big are not stored

### DIFF
--- a/src/main/java/org/htmlunit/httpclient/HtmlUnitMaxAgeHandler.java
+++ b/src/main/java/org/htmlunit/httpclient/HtmlUnitMaxAgeHandler.java
@@ -15,6 +15,7 @@
 package org.htmlunit.httpclient;
 
 import java.util.Date;
+import java.util.regex.Pattern;
 
 import org.apache.http.cookie.MalformedCookieException;
 import org.apache.http.cookie.SetCookie;
@@ -25,22 +26,36 @@ import org.apache.http.util.Args;
  * Customized BasicMaxAgeHandler for HtmlUnit.
  *
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 final class HtmlUnitMaxAgeHandler extends BasicMaxAgeHandler {
+
+    // Max-Age should be 400 days at most
+    // https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#section-5.5
+    private static final int MAX_MAX_AGE = 400 * 24 * 60 * 60;
+
+    private static final Pattern MAX_AGE_PATTERN = Pattern.compile("-?[0-9]+");
 
     @Override
     public void parse(final SetCookie cookie, final String value)
             throws MalformedCookieException {
         Args.notNull(cookie, "Cookie");
-        if (value == null) {
+        if (value == null || value.isEmpty()) {
             throw new MalformedCookieException("Missing value for 'max-age' attribute");
         }
-        final int age;
+        if (!MAX_AGE_PATTERN.matcher(value).matches()) {
+            throw new MalformedCookieException("Invalid 'max-age' attribute: " + value);
+        }
+        if (value.startsWith("-")) {
+            cookie.setExpiryDate(new Date(0L));
+            return;
+        }
+        int age;
         try {
-            age = Integer.parseInt(value);
+            age = Math.min(Integer.parseInt(value), MAX_MAX_AGE);
         }
         catch (final NumberFormatException e) {
-            throw new MalformedCookieException("Invalid 'max-age' attribute: " + value, e);
+            age = MAX_MAX_AGE;
         }
         cookie.setExpiryDate(new Date(System.currentTimeMillis() + age * 1000L));
     }


### PR DESCRIPTION
## This PR does the following

Fix `HtmlUnitMaxAgeHandler` to correctly handle cookies with large, negative, or non-numeric `max-age` values per RFC 6265.

## Problem

When a server sends a cookie with a `max-age` value that exceeds `Integer.MAX_VALUE` (e.g `max-age=99999999999`), `Integer.parseInt` throws `NumberFormatException`, which is wrapped into `MalformedCookieException`, causing the **entire cookie to be rejected**.

Per [RFC 6265](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#section-5.6.2), large values should be capped to a limit (400 days) rather than rejected.

Additionally, negative/zero delta-seconds should set expiry to the earliest representable date instead of offsetting current time.