### PR TITLE
Fix Storage's storeSize calculation when overwriting existing key

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/Storage.java
+++ b/src/main/java/org/htmlunit/javascript/host/Storage.java
@@ -35,6 +35,7 @@ import org.w3c.dom.DOMException;
  * @author Ahmed Ashour
  * @author Marc Guillemot
  * @author Ronald Brill
+ * @author Kanoko Yamamoto
  */
 @JsxClass
 public class Storage extends HtmlUnitScriptable {
@@ -164,7 +165,8 @@ public class Storage extends HtmlUnitScriptable {
      */
     @JsxFunction
     public void setItem(final String key, final String data) {
-        final long storeSize = storeSize_ + data.length();
+        final String existingData = store_.get(key);
+        final long storeSize = storeSize_ + data.length() - (existingData != null ? existingData.length() : 0);
         if (storeSize > STORE_SIZE_KIMIT) {
             throw JavaScriptEngine.throwAsScriptRuntimeEx(
                     new DOMException((short) 22, "QuotaExceededError: Failed to execute 'setItem' on 'Storage': "


### PR DESCRIPTION
## This PR does the following

Fix `Storage.setItem` to correctly calculate store size when overwriting an existing key.

## Problem

When `setItem` is called with a key that already exists, the store size calculation only adds the new value's length without subtracting the old value's length. This causes `storeSize_` to grow monotonically even when the actual stored data size stays the same or shrinks, eventually triggering a spurious `QuotaExceededError`.

## Reproducing

```java
storage.setItem("key", "aaa"); // storeSize_ = 3
storage.setItem("key", "bb");  // storeSize_ = 5 (should be 2)
storage.setItem("key", "c");   // storeSize_ = 6 (should be 1)
```

After enough overwrites, `storeSize_` exceeds `STORE_SIZE_KIMIT` even though the store only holds a single small value.