### PR TITLE
Intl improvement: Locale, getCanonicalLocales, supportedLocalesOf

### DIFF
--- a/src/main/java/org/htmlunit/javascript/JavaScriptEngine.java
+++ b/src/main/java/org/htmlunit/javascript/JavaScriptEngine.java
@@ -454,10 +454,7 @@ public class JavaScriptEngine implements AbstractJavaScriptEngine<Script> {
         }
 
         // add Intl
-        final Intl intl = new Intl();
-        intl.setParentScope(scope);
-        globalThis.defineProperty(intl.getClassName(), intl, ScriptableObject.DONTENUM);
-        intl.defineProperties(scope, browserVersion);
+        Intl.init(scope, globalThis, browserVersion);
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/intl/DateTimeFormat.java
+++ b/src/main/java/org/htmlunit/javascript/host/intl/DateTimeFormat.java
@@ -37,6 +37,7 @@ import org.htmlunit.javascript.JavaScriptEngine;
 import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
 import org.htmlunit.javascript.configuration.JsxFunction;
+import org.htmlunit.javascript.configuration.JsxStaticFunction;
 import org.htmlunit.javascript.host.Window;
 import org.htmlunit.util.StringUtils;
 
@@ -303,6 +304,18 @@ public class DateTimeFormat extends HtmlUnitScriptable {
             options.put("locale", options, formatter_.locale_);
         }
         return options;
+    }
+
+    /**
+     * Returns an array containing those of the provided locales that are supported
+     * without having to fall back to the default locale.
+     * @param localesArgument A string with a BCP 47 language tag, or an array of such strings
+     * @param options unused
+     * @return an array containing supported locales
+     */
+    @JsxStaticFunction
+    public static Scriptable supportedLocalesOf(final Scriptable localesArgument, final Scriptable options) {
+        return Intl.supportedLocalesOf(localesArgument);
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
+++ b/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
@@ -17,17 +17,27 @@ package org.htmlunit.javascript.host.intl;
 import static org.htmlunit.BrowserVersionFeatures.JS_INTL_V8_BREAK_ITERATOR;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.IllformedLocaleException;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.htmlunit.BrowserVersion;
+import org.htmlunit.corejs.javascript.Context;
+import org.htmlunit.corejs.javascript.Function;
 import org.htmlunit.corejs.javascript.FunctionObject;
+import org.htmlunit.corejs.javascript.NativeArray;
 import org.htmlunit.corejs.javascript.Scriptable;
 import org.htmlunit.corejs.javascript.ScriptableObject;
+import org.htmlunit.corejs.javascript.TopLevel;
 import org.htmlunit.javascript.HtmlUnitScriptable;
 import org.htmlunit.javascript.JavaScriptEngine;
 import org.htmlunit.javascript.configuration.AbstractJavaScriptConfiguration;
 import org.htmlunit.javascript.configuration.ClassConfiguration;
 import org.htmlunit.javascript.configuration.JsxClass;
+import org.htmlunit.javascript.configuration.JsxStaticFunction;
 
 /**
  * A JavaScript object for {@code Intl}.
@@ -94,5 +104,73 @@ public class Intl extends HtmlUnitScriptable {
                 target.defineProperty(entry.getKey(), fn, ScriptableObject.EMPTY);
             }
         }
+    }
+
+    /**
+     * Returns an array containing the canonical locale names.
+     * Duplicates will be omitted and elements will be validated as structurally valid language tags.
+     *
+     * @param cx the current context
+     * @param thisObj the scriptable this
+     * @param args the arguments
+     * @param funObj the function object
+     * @return an array of canonical locale names
+     *
+     * @see <a href="https://tc39.es/ecma402/#sec-intl.getcanonicallocales">spec</a>
+     */
+    @JsxStaticFunction
+    public static Object getCanonicalLocales(final Context cx, final Scriptable thisObj,
+            final Object[] args, final Function funObj) {
+        if (args.length == 0 || JavaScriptEngine.isUndefined(args[0])) {
+            return cx.newArray(TopLevel.getTopLevelScope(thisObj), new Object[0]);
+        }
+
+        final Object localesArgument = args[0];
+        if (localesArgument == null) {
+            throw JavaScriptEngine.typeError("Cannot convert null to object");
+        }
+
+        final List<String> languageTags = new ArrayList<>();
+        if (localesArgument instanceof String s) {
+            languageTags.add(s);
+        }
+        else if (localesArgument instanceof Scriptable scriptable) {
+            if ("String".equals(scriptable.getClassName()) || scriptable instanceof Locale) {
+                languageTags.add(scriptable.toString());
+            }
+            else if (scriptable instanceof NativeArray array) {
+                for (int i = 0; i < array.getLength(); i++) {
+                    final Object elem = array.get(i);
+                    if (elem instanceof String s) {
+                        languageTags.add(s);
+                    }
+                    else if (elem instanceof Locale) {
+                        languageTags.add(elem.toString());
+                    }
+                    else if (elem instanceof ScriptableObject) {
+                        languageTags.add(JavaScriptEngine.toString(elem));
+                    }
+                    else {
+                        throw JavaScriptEngine.typeError("Invalid element in locales argument");
+                    }
+                }
+            }
+            else {
+                languageTags.add(JavaScriptEngine.toString(localesArgument));
+            }
+        }
+
+        final Set<String> canonicalLocales = new LinkedHashSet<>(languageTags.size());
+        for (final String tag : languageTags) {
+            try {
+                canonicalLocales.add(
+                        new java.util.Locale.Builder().setLanguageTag(tag).build().toLanguageTag());
+            }
+            catch (final IllformedLocaleException e) {
+                throw JavaScriptEngine.rangeError("Invalid language tag: " + tag);
+            }
+        }
+
+        return cx.newArray(TopLevel.getTopLevelScope(thisObj), canonicalLocales.toArray());
     }
 }

--- a/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
+++ b/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.LocaleUtils;
 import org.htmlunit.BrowserVersion;
 import org.htmlunit.corejs.javascript.Context;
 import org.htmlunit.corejs.javascript.Function;
@@ -60,7 +61,7 @@ public class Intl extends HtmlUnitScriptable {
         intl.setParentScope(scope);
         intl.defineProperties(scope, browserVersion);
 
-        // Configure static functions
+        // Configure static functions (getCanonicalLocales)
         final ClassConfiguration intlConfig = AbstractJavaScriptConfiguration.getClassConfiguration(Intl.class, browserVersion);
         if (intlConfig != null) {
             defineStaticFunctions(intlConfig, intl, intl);
@@ -172,5 +173,37 @@ public class Intl extends HtmlUnitScriptable {
         }
 
         return cx.newArray(TopLevel.getTopLevelScope(thisObj), canonicalLocales.toArray());
+    }
+
+    /**
+     * Shared utility for {@code supportedLocalesOf} implementations.
+     * @param localesArgument the locales argument
+     * @return a Scriptable array of supported locale strings
+     */
+    static Scriptable supportedLocalesOf(final Scriptable localesArgument) {
+        final String[] locales;
+        if (localesArgument instanceof NativeArray array) {
+            locales = new String[(int) array.getLength()];
+            for (int i = 0; i < locales.length; i++) {
+                locales[i] = JavaScriptEngine.toString(array.get(i));
+            }
+        }
+        else {
+            locales = new String[] {JavaScriptEngine.toString(localesArgument)};
+        }
+
+        final List<String> supportedLocales = new ArrayList<>();
+        for (final String locale : locales) {
+            if (locale.isEmpty()) {
+                throw JavaScriptEngine.rangeError("Invalid language tag: " + locale);
+            }
+            final java.util.Locale l = java.util.Locale.forLanguageTag(locale);
+            if (LocaleUtils.isAvailableLocale(l)) {
+                supportedLocales.add(locale);
+            }
+        }
+
+        return Context.getCurrentContext().newArray(
+                TopLevel.getTopLevelScope(localesArgument), supportedLocales.toArray());
     }
 }

--- a/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
+++ b/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
@@ -16,6 +16,9 @@ package org.htmlunit.javascript.host.intl;
 
 import static org.htmlunit.BrowserVersionFeatures.JS_INTL_V8_BREAK_ITERATOR;
 
+import java.lang.reflect.Method;
+import java.util.Map;
+
 import org.htmlunit.BrowserVersion;
 import org.htmlunit.corejs.javascript.FunctionObject;
 import org.htmlunit.corejs.javascript.Scriptable;
@@ -24,20 +27,39 @@ import org.htmlunit.javascript.HtmlUnitScriptable;
 import org.htmlunit.javascript.JavaScriptEngine;
 import org.htmlunit.javascript.configuration.AbstractJavaScriptConfiguration;
 import org.htmlunit.javascript.configuration.ClassConfiguration;
+import org.htmlunit.javascript.configuration.JsxClass;
 
 /**
  * A JavaScript object for {@code Intl}.
  *
  * @author Ahmed Ashour
+ * @author Lai Quang Duong
  */
+@JsxClass
 public class Intl extends HtmlUnitScriptable {
 
     /**
-     * Define needed properties.
-     * @param scope the scope
+     * Initialize the Intl object and register it on the global scope.
+     * @param scope the top-level scope
+     * @param globalThis the global object
      * @param browserVersion the browser version
      */
-    public void defineProperties(final Scriptable scope, final BrowserVersion browserVersion) {
+    public static void init(final Scriptable scope, final ScriptableObject globalThis,
+            final BrowserVersion browserVersion) {
+        final Intl intl = new Intl();
+        intl.setParentScope(scope);
+        intl.defineProperties(scope, browserVersion);
+
+        // Configure static functions
+        final ClassConfiguration intlConfig = AbstractJavaScriptConfiguration.getClassConfiguration(Intl.class, browserVersion);
+        if (intlConfig != null) {
+            defineStaticFunctions(intlConfig, intl, intl);
+        }
+
+        globalThis.defineProperty(intl.getClassName(), intl, ScriptableObject.DONTENUM);
+    }
+
+    private void defineProperties(final Scriptable scope, final BrowserVersion browserVersion) {
         define(scope, Collator.class, browserVersion);
         define(scope, DateTimeFormat.class, browserVersion);
         define(scope, Locale.class, browserVersion);
@@ -52,13 +74,25 @@ public class Intl extends HtmlUnitScriptable {
         try {
             final ClassConfiguration config = AbstractJavaScriptConfiguration.getClassConfiguration(c, browserVersion);
             final HtmlUnitScriptable prototype = JavaScriptEngine.configureClass(config, scope);
-            final FunctionObject functionObject =
-                    new FunctionObject(config.getJsConstructor().getKey(),
-                            config.getJsConstructor().getValue(), this);
-            functionObject.addAsConstructor(this, prototype, ScriptableObject.DONTENUM);
+            final FunctionObject constructorFn = new FunctionObject(config.getJsConstructor().getKey(),
+                    config.getJsConstructor().getValue(), this);
+            constructorFn.addAsConstructor(this, prototype, ScriptableObject.DONTENUM);
+
+            defineStaticFunctions(config, this, constructorFn);
         }
         catch (final Exception e) {
             throw JavaScriptEngine.throwAsScriptRuntimeEx(e);
+        }
+    }
+
+    private static void defineStaticFunctions(final ClassConfiguration config,
+            final Scriptable scope, final ScriptableObject target) {
+        final Map<String, Method> staticFunctionMap = config.getStaticFunctionMap();
+        if (staticFunctionMap != null) {
+            for (final Map.Entry<String, Method> entry : staticFunctionMap.entrySet()) {
+                final FunctionObject fn = new FunctionObject(entry.getKey(), entry.getValue(), scope);
+                target.defineProperty(entry.getKey(), fn, ScriptableObject.EMPTY);
+            }
         }
     }
 }

--- a/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
+++ b/src/main/java/org/htmlunit/javascript/host/intl/Intl.java
@@ -40,6 +40,7 @@ public class Intl extends HtmlUnitScriptable {
     public void defineProperties(final Scriptable scope, final BrowserVersion browserVersion) {
         define(scope, Collator.class, browserVersion);
         define(scope, DateTimeFormat.class, browserVersion);
+        define(scope, Locale.class, browserVersion);
         define(scope, NumberFormat.class, browserVersion);
         if (browserVersion.hasFeature(JS_INTL_V8_BREAK_ITERATOR)) {
             define(scope, V8BreakIterator.class, browserVersion);

--- a/src/main/java/org/htmlunit/javascript/host/intl/Locale.java
+++ b/src/main/java/org/htmlunit/javascript/host/intl/Locale.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2002-2026 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit.javascript.host.intl;
+
+import java.util.IllformedLocaleException;
+import java.util.List;
+
+import org.apache.commons.lang3.LocaleUtils;
+import org.htmlunit.corejs.javascript.Context;
+import org.htmlunit.corejs.javascript.Function;
+import org.htmlunit.corejs.javascript.FunctionObject;
+import org.htmlunit.corejs.javascript.Scriptable;
+import org.htmlunit.corejs.javascript.ScriptableObject;
+import org.htmlunit.javascript.HtmlUnitScriptable;
+import org.htmlunit.javascript.JavaScriptEngine;
+import org.htmlunit.javascript.configuration.JsxClass;
+import org.htmlunit.javascript.configuration.JsxConstructor;
+import org.htmlunit.javascript.configuration.JsxFunction;
+import org.htmlunit.javascript.configuration.JsxGetter;
+
+/**
+ * A JavaScript object for {@code Intl.Locale}.
+ *
+ * @author Lai Quang Duong
+ */
+@JsxClass
+public class Locale extends HtmlUnitScriptable {
+
+    private static final List<String> ALLOWED_HOUR_CYCLES = List.of("h11", "h12", "h23", "h24");
+    private static final List<String> ALLOWED_CASE_FIRSTS = List.of("upper", "lower", "false");
+
+    private java.util.Locale locale_;
+    private String language_;
+    private String script_;
+    private String region_;
+    private String calendar_;
+    private String collation_;
+    private String numberingSystem_;
+    private String caseFirst_;
+    private String hourCycle_;
+    private boolean numeric_;
+
+    /**
+     * Default constructor.
+     */
+    public Locale() {
+        super();
+    }
+
+    private Locale(final java.util.Locale locale) {
+        super();
+        locale_ = locale;
+        language_ = locale.getLanguage();
+        if (!locale.getScript().isEmpty()) {
+            script_ = locale.getScript();
+        }
+        if (!locale.getCountry().isEmpty()) {
+            region_ = locale.getCountry();
+        }
+        if (locale.hasExtensions()) {
+            calendar_ = locale.getUnicodeLocaleType("ca");
+            collation_ = locale.getUnicodeLocaleType("co");
+            numberingSystem_ = locale.getUnicodeLocaleType("nu");
+            caseFirst_ = locale.getUnicodeLocaleType("kf");
+            hourCycle_ = locale.getUnicodeLocaleType("hc");
+            numeric_ = Boolean.parseBoolean(locale.getUnicodeLocaleType("kn"));
+        }
+    }
+
+    /**
+     * JavaScript constructor.
+     * @param cx the current context
+     * @param scope the scope
+     * @param args the arguments
+     * @param ctorObj the constructor function
+     * @param inNewExpr whether called via new
+     * @return the new Locale instance
+     */
+    @JsxConstructor
+    public static Scriptable jsConstructor(final Context cx, final Scriptable scope,
+            final Object[] args, final Function ctorObj, final boolean inNewExpr) {
+        if (args.length == 0 || JavaScriptEngine.isUndefined(args[0])) {
+            throw JavaScriptEngine.typeError("Invalid element in locales argument");
+        }
+
+        final String languageTag;
+        if (args[0] instanceof Locale loc) {
+            languageTag = loc.toString();
+        }
+        else {
+            languageTag = JavaScriptEngine.toString(args[0]);
+        }
+        if (languageTag.isEmpty()) {
+            throw JavaScriptEngine.rangeError("Invalid language tag: ");
+        }
+
+        java.util.Locale locale;
+        try {
+            locale = new java.util.Locale.Builder()
+                    .setLanguageTag(languageTag)
+                    .build();
+        }
+        catch (final IllformedLocaleException e) {
+            throw JavaScriptEngine.rangeError("Invalid language tag: " + languageTag);
+        }
+
+        // Override by options if present
+        if (args.length > 1 && !JavaScriptEngine.isUndefined(args[1])) {
+            locale = overrideExistingWithOptions(locale,
+                    ScriptableObject.ensureScriptableObject(args[1]));
+        }
+
+        final Locale l = new Locale(locale);
+        l.setParentScope(getTopLevelScope(ctorObj));
+        l.setPrototype(((FunctionObject) ctorObj).getClassPrototype());
+        return l;
+    }
+
+    private static java.util.Locale overrideExistingWithOptions(
+            final java.util.Locale existing, final ScriptableObject options) {
+        final java.util.Locale.Builder builder = new java.util.Locale.Builder().setLocale(existing);
+
+        setStringOption(builder, options, "language");
+        setStringOption(builder, options, "script");
+        setStringOption(builder, options, "region");
+        setUnicodeKeyword(builder, options, "calendar", "ca", null);
+        setUnicodeKeyword(builder, options, "collation", "co", null);
+        setUnicodeKeyword(builder, options, "numberingSystem", "nu", null);
+        setUnicodeKeyword(builder, options, "caseFirst", "kf", ALLOWED_CASE_FIRSTS);
+        setUnicodeKeyword(builder, options, "hourCycle", "hc", ALLOWED_HOUR_CYCLES);
+
+        final Object numeric = ScriptableObject.getProperty(options, "numeric");
+        if (numeric != Scriptable.NOT_FOUND && !JavaScriptEngine.isUndefined(numeric)) {
+            final boolean isNumeric = numeric instanceof Boolean ? (Boolean) numeric : true;
+            builder.setUnicodeLocaleKeyword("kn", Boolean.toString(isNumeric));
+        }
+
+        return builder.build();
+    }
+
+    private static void setStringOption(final java.util.Locale.Builder builder,
+            final ScriptableObject options, final String optionName) {
+        final Object value = ScriptableObject.getProperty(options, optionName);
+        if (value == Scriptable.NOT_FOUND || JavaScriptEngine.isUndefined(value)) {
+            return;
+        }
+        try {
+            final String s = JavaScriptEngine.toString(value);
+            switch (optionName) {
+                case "language":
+                    builder.setLanguage(s);
+                    break;
+                case "script":
+                    builder.setScript(s);
+                    break;
+                case "region":
+                    builder.setRegion(s);
+                    break;
+                default:
+                    break;
+            }
+        }
+        catch (final Exception e) {
+            throw JavaScriptEngine.rangeError("Invalid value for option \"" + optionName + "\"");
+        }
+    }
+
+    private static void setUnicodeKeyword(final java.util.Locale.Builder builder,
+            final ScriptableObject options, final String optionName, final String unicodeKey,
+            final List<String> allowedValues) {
+        final Object value = ScriptableObject.getProperty(options, optionName);
+        if (value == Scriptable.NOT_FOUND || JavaScriptEngine.isUndefined(value)) {
+            return;
+        }
+        final String s;
+        try {
+            s = JavaScriptEngine.toString(value);
+        }
+        catch (final Exception e) {
+            throw JavaScriptEngine.rangeError("Invalid value for option \"" + optionName + "\"");
+        }
+        if (allowedValues != null && !allowedValues.contains(s)) {
+            throw JavaScriptEngine.rangeError("Invalid value for option \"" + optionName + "\"");
+        }
+        builder.setUnicodeLocaleKeyword(unicodeKey, s);
+    }
+
+    /** @return the language */
+    @JsxGetter
+    public Object getLanguage() {
+        return language_ != null ? language_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return the script */
+    @JsxGetter
+    public Object getScript() {
+        return script_ != null ? script_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return the region */
+    @JsxGetter
+    public Object getRegion() {
+        return region_ != null ? region_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return the calendar type */
+    @JsxGetter
+    public Object getCalendar() {
+        return calendar_ != null ? calendar_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return the collation type */
+    @JsxGetter
+    public Object getCollation() {
+        return collation_ != null ? collation_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return the numbering system */
+    @JsxGetter
+    public Object getNumberingSystem() {
+        return numberingSystem_ != null ? numberingSystem_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return the case first setting */
+    @JsxGetter
+    public Object getCaseFirst() {
+        return caseFirst_ != null ? caseFirst_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return the hour cycle */
+    @JsxGetter
+    public Object getHourCycle() {
+        return hourCycle_ != null ? hourCycle_ : JavaScriptEngine.UNDEFINED;
+    }
+
+    /** @return whether numeric sorting is used */
+    @JsxGetter
+    public boolean isNumeric() {
+        return numeric_;
+    }
+
+    /** @return the base name (without Unicode extensions) */
+    @JsxGetter
+    public Object getBaseName() {
+        final String variant = locale_.getVariant().replace("_", "-");
+        return language_
+                + (script_ != null ? "-" + script_ : "")
+                + (region_ != null ? "-" + region_ : "")
+                + (!variant.isEmpty() ? "-" + variant : "");
+    }
+
+    /**
+     * Returns a Locale with maximized subtags.
+     * @return a new Locale instance with maximized subtags
+     */
+    @JsxFunction
+    public Object maximize() {
+        final String region;
+        if (region_ != null) {
+            region = region_;
+        }
+        else {
+            final java.util.List<java.util.Locale> locales =
+                    LocaleUtils.countriesByLanguage(language_);
+            if (!locales.isEmpty()) {
+                region = locales.get(0).getCountry();
+            }
+            else {
+                region = null;
+            }
+        }
+
+        final java.util.Locale locale = new java.util.Locale.Builder()
+                .setLanguage(language_)
+                .setScript(script_)
+                .setRegion(region)
+                .setExtension('u', locale_.getExtension('u'))
+                .build();
+
+        final Locale l = new Locale(locale);
+        l.setParentScope(getWindow(this));
+        l.setPrototype(this.getPrototype());
+        return l;
+    }
+
+    /**
+     * Returns a Locale with minimized subtags.
+     * @return a new Locale instance with minimized subtags
+     */
+    @JsxFunction
+    public Object minimize() {
+        final java.util.Locale locale = new java.util.Locale.Builder()
+                .setLanguage(language_)
+                .setExtension('u', locale_.getExtension('u'))
+                .build();
+
+        final Locale l = new Locale(locale);
+        l.setParentScope(getWindow(this));
+        l.setPrototype(this.getPrototype());
+        return l;
+    }
+
+    /**
+     * @return the locale's Unicode locale identifier string
+     */
+    @Override
+    @JsxFunction
+    public String toString() {
+        if (locale_ == null) {
+            return super.toString();
+        }
+        return locale_.toLanguageTag();
+    }
+}

--- a/src/main/java/org/htmlunit/javascript/host/intl/NumberFormat.java
+++ b/src/main/java/org/htmlunit/javascript/host/intl/NumberFormat.java
@@ -32,6 +32,7 @@ import org.htmlunit.javascript.JavaScriptEngine;
 import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
 import org.htmlunit.javascript.configuration.JsxFunction;
+import org.htmlunit.javascript.configuration.JsxStaticFunction;
 import org.htmlunit.javascript.host.Window;
 import org.htmlunit.util.StringUtils;
 
@@ -207,6 +208,18 @@ public class NumberFormat extends HtmlUnitScriptable {
     @JsxFunction
     public Scriptable resolvedOptions() {
         return JavaScriptEngine.newObject(getParentScope());
+    }
+
+    /**
+     * Returns an array containing those of the provided locales that are supported
+     * without having to fall back to the default locale.
+     * @param localesArgument A string with a BCP 47 language tag, or an array of such strings
+     * @param options unused
+     * @return an array containing supported locales
+     */
+    @JsxStaticFunction
+    public static Scriptable supportedLocalesOf(final Scriptable localesArgument, final Scriptable options) {
+        return Intl.supportedLocalesOf(localesArgument);
     }
 
     /**

--- a/src/test/java/org/htmlunit/javascript/host/intl/DateTimeFormatTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/intl/DateTimeFormatTest.java
@@ -434,4 +434,27 @@ public class DateTimeFormatTest extends WebDriverTestCase {
             shutDownAll();
         }
     }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"en", "en,ja", ""})
+    public void supportedLocalesOf() throws Exception {
+        final String html = DOCTYPE_HTML
+                + "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log(Intl.DateTimeFormat.supportedLocalesOf('en'));\n"
+                + "    log(Intl.DateTimeFormat.supportedLocalesOf(['en', 'xx-YY', 'ja']));\n"
+                + "    log(Intl.DateTimeFormat.supportedLocalesOf([]));\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
 }

--- a/src/test/java/org/htmlunit/javascript/host/intl/IntlTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/intl/IntlTest.java
@@ -100,4 +100,39 @@ public class IntlTest extends WebDriverTestCase {
         test("Intl.v8BreakIterator");
     }
 
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"en-US", "en-US,fr-FR,ja-JP",
+             "zh-Hant-TW", "en-Latn-US",
+             "ja-JP", "en-US,fr", "en-US", "ja-JP",
+             "TypeError", "", "", "RangeError", "RangeError", ""})
+    public void getCanonicalLocales() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    log(Intl.getCanonicalLocales('EN-us'));\n"
+            + "    log(Intl.getCanonicalLocales(['en-US', 'fr-FR', 'ja-JP', 'EN-US']));\n"
+            + "    log(Intl.getCanonicalLocales('zh-hant-tw'));\n"
+            + "    log(Intl.getCanonicalLocales('en-latn-us'));\n"
+            + "    log(Intl.getCanonicalLocales(new Intl.Locale('ja-JP')));\n"
+            + "    log(Intl.getCanonicalLocales([new Intl.Locale('en-US'), new Intl.Locale('fr')]));\n"
+            + "    log(Intl.getCanonicalLocales(new String('en-US')));\n"
+            + "    log(Intl.getCanonicalLocales([new String('ja-JP')]));\n"
+            + "    try { log(Intl.getCanonicalLocales(null)); } catch(e) { logEx(e) }\n"
+            + "    try { log(Intl.getCanonicalLocales(undefined)); } catch(e) { logEx(e) }\n"
+            + "    try { log(Intl.getCanonicalLocales([])); } catch(e) { logEx(e) }\n"
+            + "    try { log(Intl.getCanonicalLocales('')); } catch(e) { logEx(e) }\n"
+            + "    try { log(Intl.getCanonicalLocales('en-US!@#')); } catch(e) { logEx(e) }\n"
+            + "    try { log(Intl.getCanonicalLocales(42)); } catch(e) { logEx(e) }\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
 }

--- a/src/test/java/org/htmlunit/javascript/host/intl/IntlTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/intl/IntlTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 public class IntlTest extends WebDriverTestCase {
 
@@ -77,6 +78,15 @@ public class IntlTest extends WebDriverTestCase {
     @Alerts("function NumberFormat() { [native code] }")
     public void numberFormat() throws Exception {
         test("Intl.NumberFormat");
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts("function Locale() { [native code] }")
+    public void locale() throws Exception {
+        test("Intl.Locale");
     }
 
     /**

--- a/src/test/java/org/htmlunit/javascript/host/intl/LocaleTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/intl/LocaleTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2002-2026 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit.javascript.host.intl;
+
+import org.htmlunit.WebDriverTestCase;
+import org.htmlunit.junit.annotation.Alerts;
+import org.htmlunit.junit.annotation.HtmlUnitNYI;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Locale}.
+ *
+ * @author Lai Quang Duong
+ */
+public class LocaleTest extends WebDriverTestCase {
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"en", "undefined", "undefined", "en", "en",
+             "zh", "undefined", "Hant", "zh-Hant", "zh-Hant",
+             "zh", "TW", "Hant", "zh-Hant-TW", "zh-Hant-TW",
+             "ja", "JP", "undefined", "ja-JP", "ja-JP",
+             "en", "US", "undefined", "en-US", "en-US",
+             "ja-JP"})
+    public void construction() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    function check(l) { log(l.language); log(l.region); log(l.script); log(l.baseName); log(l.toString()); }\n"
+            + "    check(new Intl.Locale('en'));\n"
+            + "    check(new Intl.Locale('zh-Hant'));\n"
+            + "    check(new Intl.Locale('zh-Hant-TW'));\n"
+            + "    check(new Intl.Locale('ja-JP'));\n"
+            + "    check(new Intl.Locale('EN-US'));\n"
+            + "    log(new Intl.Locale(new Intl.Locale('ja-JP')).toString());\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"TypeError", "RangeError", "RangeError", "RangeError",
+             "invalid", "en-US", "RangeError", "RangeError"})
+    public void constructorErrors() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function tryLocale(tag) { try { log(new Intl.Locale(tag).toString()); } catch(e) { logEx(e) } }\n"
+            + "  function test() {\n"
+            + "    try { new Intl.Locale(); } catch(e) { logEx(e) }\n"
+            + "    tryLocale('123');\n"
+            + "    tryLocale('');\n"
+            + "    tryLocale('a');\n"
+            + "    tryLocale('invalid');\n"
+            + "    tryLocale(['en-US']);\n"
+            + "    tryLocale([]);\n"
+            + "    tryLocale(['en-US', 'fr']);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"undefined", "undefined", "undefined", "undefined", "undefined", "false",
+             "buddhist", "emoji", "latn", "h23", "lower", "true",
+             "ja", "JP", "Jpan", "japanese", "h12", "ja-Jpan-JP",
+             "de", "phonebk", "de-u-co-phonebk",
+             "th", "TH", "thai", "th-TH-u-nu-thai",
+             "en", "upper", "en-u-kf-upper"})
+    public void extensions() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    function check(l) { log(l.calendar); log(l.collation); log(l.numberingSystem); log(l.hourCycle); log(l.caseFirst); log(l.numeric); }\n"
+            + "    check(new Intl.Locale('en-US'));\n"
+            + "    check(new Intl.Locale('en-US-u-ca-buddhist-co-emoji-nu-latn-hc-h23-kf-lower-kn-true'));\n"
+            + "    var l = new Intl.Locale('ja-Jpan-JP-u-ca-japanese-hc-h12');\n"
+            + "    log(l.language); log(l.region); log(l.script);\n"
+            + "    log(l.calendar); log(l.hourCycle); log(l.baseName);\n"
+            + "    var co = new Intl.Locale('de-u-co-phonebk');\n"
+            + "    log(co.language); log(co.collation); log(co.toString());\n"
+            + "    var nu = new Intl.Locale('th-TH-u-nu-thai');\n"
+            + "    log(nu.language); log(nu.region); log(nu.numberingSystem); log(nu.toString());\n"
+            + "    var kf = new Intl.Locale('en-u-kf-upper');\n"
+            + "    log(kf.language); log(kf.caseFirst); log(kf.toString());\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"en", "true", "en-u-kn",
+             "false", "en-u-kn-false",
+             "false", "en-u-kn-false"})
+    @HtmlUnitNYI(CHROME = {"en", "true", "en-u-kn-true",
+                           "false", "en-u-kn-false",
+                           "false", "en-u-kn-false"},
+            EDGE = {"en", "true", "en-u-kn-true",
+                    "false", "en-u-kn-false",
+                    "false", "en-u-kn-false"},
+            FF = {"en", "true", "en-u-kn-true",
+                  "false", "en-u-kn-false",
+                  "false", "en-u-kn-false"},
+            FF_ESR = {"en", "true", "en-u-kn-true",
+                      "false", "en-u-kn-false",
+                      "false", "en-u-kn-false"})
+    public void numeric() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    var l = new Intl.Locale('en-u-kn-true');\n"
+            + "    log(l.language); log(l.numeric); log(l.toString());\n"
+            + "    var l1 = new Intl.Locale('en-u-kn-false');\n"
+            + "    log(l1.numeric); log(l1.toString());\n"
+            + "    var l2 = new Intl.Locale('en', {numeric: false});\n"
+            + "    log(l2.numeric); log(l2.toString());\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"en", "RU", "Cyrl", "buddhist", "zhuyin", "thai", "h11", "true",
+             "en", "CA", "en-CA",
+             "en", "GB", "en-GB",
+             "islamic", "en-US-u-ca-islamic",
+             "buddhist", "en-US-u-ca-buddhist"})
+    public void optionsOverride() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    var l = new Intl.Locale('fr-Latn-CA', {\n"
+            + "      language: 'en', script: 'Cyrl', region: 'RU',\n"
+            + "      calendar: 'buddhist', collation: 'zhuyin',\n"
+            + "      numberingSystem: 'thai', hourCycle: 'h11',\n"
+            + "      numeric: true\n"
+            + "    });\n"
+            + "    log(l.language); log(l.region); log(l.script);\n"
+            + "    log(l.calendar); log(l.collation); log(l.numberingSystem);\n"
+            + "    log(l.hourCycle); log(l.numeric);\n"
+            + "    var l1 = new Intl.Locale('fr-CA', {language: 'en'});\n"
+            + "    log(l1.language); log(l1.region); log(l1.toString());\n"
+            + "    var l2 = new Intl.Locale('en-US', {region: 'GB'});\n"
+            + "    log(l2.language); log(l2.region); log(l2.toString());\n"
+            + "    var l3 = new Intl.Locale('en-US', {calendar: 'islamic'});\n"
+            + "    log(l3.calendar); log(l3.toString());\n"
+            + "    var l4 = new Intl.Locale('en-US-u-ca-gregory', {calendar: 'buddhist'});\n"
+            + "    log(l4.calendar); log(l4.toString());\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"RangeError", "RangeError", "RangeError", "RangeError", "RangeError"})
+    public void invalidOptions() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    try { new Intl.Locale('en', {language: '123'}); } catch(e) { logEx(e) }\n"
+            + "    try { new Intl.Locale('en', {region: 'TOOLONG'}); } catch(e) { logEx(e) }\n"
+            + "    try { new Intl.Locale('en', {script: 'X'}); } catch(e) { logEx(e) }\n"
+            + "    try { new Intl.Locale('en', {hourCycle: 'invalid'}); } catch(e) { logEx(e) }\n"
+            + "    try { new Intl.Locale('en', {caseFirst: 'invalid'}); } catch(e) { logEx(e) }\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"ja-Jpan-JP-u-ca-japanese-hc-h12",
+             "ja-u-ca-japanese-hc-h12",
+             "ja-Jpan-JP-u-ca-japanese-hc-h12",
+             "ja-Jpan-JP"})
+    @HtmlUnitNYI(CHROME = {"ja-Jpan-JP-u-ca-japanese-hc-h12",
+                           "ja-u-ca-japanese-hc-h12",
+                           "ja-JP-u-ca-japanese-hc-h12",
+                           "ja-Jpan-JP"},
+            EDGE = {"ja-Jpan-JP-u-ca-japanese-hc-h12",
+                    "ja-u-ca-japanese-hc-h12",
+                    "ja-JP-u-ca-japanese-hc-h12",
+                    "ja-Jpan-JP"},
+            FF = {"ja-Jpan-JP-u-ca-japanese-hc-h12",
+                  "ja-u-ca-japanese-hc-h12",
+                  "ja-JP-u-ca-japanese-hc-h12",
+                  "ja-Jpan-JP"},
+            FF_ESR = {"ja-Jpan-JP-u-ca-japanese-hc-h12",
+                      "ja-u-ca-japanese-hc-h12",
+                      "ja-JP-u-ca-japanese-hc-h12",
+                      "ja-Jpan-JP"})
+    public void minimizeMaximize() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    var l = new Intl.Locale('ja-Jpan-JP-u-ca-japanese-hc-h12');\n"
+            + "    log(l.toString());\n"
+            + "    log(l.minimize().toString());\n"
+            + "    log(new Intl.Locale('ja-u-ca-japanese-hc-h12').maximize().toString());\n"
+            + "    log(l.baseName);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+}

--- a/src/test/java/org/htmlunit/javascript/host/intl/NumberFormatTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/intl/NumberFormatTest.java
@@ -111,4 +111,27 @@ public class NumberFormatTest extends WebDriverTestCase {
 
         loadPageVerifyTitle2(html);
     }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"en", "en,ja", ""})
+    public void supportedLocalesOf() throws Exception {
+        final String html = DOCTYPE_HTML
+                + "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log(Intl.NumberFormat.supportedLocalesOf('en'));\n"
+                + "    log(Intl.NumberFormat.supportedLocalesOf(['en', 'xx-YY', 'ja']));\n"
+                + "    log(Intl.NumberFormat.supportedLocalesOf([]));\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
 }


### PR DESCRIPTION
## This PR does the following
- **Refactor Intl initialization** — Move logic from `JavaScriptEngine` into `Intl.init()`, making the Intl module self-contained and enabling static function registration (for `getCanonicalLocales()` in the later commit)

- **Implement `Intl.Locale`**

- **Implement `Intl.getCanonicalLocales()`**

- **Add `supportedLocalesOf()`** to `Intl.NumberFormat` and `Intl.DateTimeFormat`