### PR TITLE
XMLHttpRequest: fix a bug where Access-Control-Allow-Origin: * was not handled correctly

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
@@ -1133,6 +1133,10 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
             if (HttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.equalsIgnoreCase(pair.getName())) {
                 String value = pair.getValue();
                 if (value != null) {
+                    if ("*".equals(value)) {
+                        // all headers are allowed
+                        return true;
+                    }
                     value = org.htmlunit.util.StringUtils.toRootLowerCase(value);
                     final String[] values = org.htmlunit.util.StringUtils.splitAtComma(value);
                     for (String part : values) {

--- a/src/test/java/org/htmlunit/javascript/host/xml/XMLHttpRequestCORSTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/xml/XMLHttpRequestCORSTest.java
@@ -619,6 +619,45 @@ public class XMLHttpRequestCORSTest extends WebDriverTestCase {
      * @throws Exception if the test fails.
      */
     @Test
+    @Alerts({"4", "200"})
+    public void preflight_wildcard_allow_headers() throws Exception {
+        expandExpectedAlertsVariables(new URL("http://localhost:" + PORT));
+
+        final String html = DOCTYPE_HTML
+                + "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "var xhr = new XMLHttpRequest();\n"
+                + "function test() {\n"
+                + "  try {\n"
+                + "    var url = 'http://' + window.location.hostname + ':" + PORT2 + "/preflight2';\n"
+                + "    xhr.open('GET', url, false);\n"
+                + "    xhr.setRequestHeader('X-PING', 'ping');\n"
+                + "    xhr.setRequestHeader('X-PONG', 'pong');\n"
+                + "    xhr.send();\n"
+                + "    log(xhr.readyState);\n"
+                + "    log(xhr.status);\n"
+                + "  } catch(e) { logEx(e) }\n"
+                + "}\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'></body></html>";
+
+        PreflightServerServlet.ACCESS_CONTROL_ALLOW_ORIGIN_ = "http://localhost:" + PORT;
+        PreflightServerServlet.ACCESS_CONTROL_ALLOW_METHODS_ = "POST, GET, OPTIONS";
+        PreflightServerServlet.ACCESS_CONTROL_ALLOW_HEADERS_ = "*";
+        final Map<String, Class<? extends Servlet>> servlets2 = new HashMap<>();
+        servlets2.put("/preflight2", PreflightServerServlet.class);
+        startWebServer2(".", servlets2);
+
+        loadPage2(html, new URL(URL_FIRST, "/preflight1"));
+        verifyTitle2(getWebDriver(), getExpectedAlerts());
+    }
+
+    /**
+     * @throws Exception if the test fails.
+     */
+    @Test
     @Alerts("false")
     public void withCredentials_defaultValue() throws Exception {
         expandExpectedAlertsVariables(new URL("http://localhost:" + PORT));


### PR DESCRIPTION
## This PR does the following

Addresses CORS preflight handling in HtmlUnit by correcting the `isPreflightAuthorized` method in `XMLHttpRequest` to properly recognize the wildcard `*` value for the `Access-Control-Allow-Headers` response header.

## Problem
When a server responds to a CORS preflight request with `Access-Control-Allow-Headers: *`, HtmlUnit does not recognize this as a wildcard. Instead, it treats `*` as a literal header name and adds it to the set of allowed header names. This causes the preflight authorization check to fail for any non-simple headers, even though the server intended to allow all of them.
