### PR TITLE
Fix a bug where input event may not be fired

### DIFF
--- a/src/main/java/org/htmlunit/html/HtmlElement.java
+++ b/src/main/java/org/htmlunit/html/HtmlElement.java
@@ -592,12 +592,8 @@ public abstract class HtmlElement extends DomElement {
         }
 
         final WebClient webClient = page.getWebClient();
-        if (this instanceof HtmlTextInput
-                || this instanceof HtmlTextArea
-                || this instanceof HtmlTelInput
-                || this instanceof HtmlNumberInput
-                || this instanceof HtmlSearchInput
-                || this instanceof HtmlPasswordInput) {
+        if (this instanceof HtmlSelectableTextInput
+                || this instanceof HtmlTextArea) {
             fireEvent(new KeyboardEvent(this, Event.TYPE_INPUT, c,
                                         shiftPressed_ || isShiftNeeded, ctrlPressed_, altPressed_));
         }

--- a/src/test/java/org/htmlunit/html/HtmlElementTest.java
+++ b/src/test/java/org/htmlunit/html/HtmlElementTest.java
@@ -1269,4 +1269,27 @@ public class HtmlElementTest extends SimpleWebTestCase {
         input.type(value);
         assertEquals(value, input.getValue());
     }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void typeFiresInputEvent() throws Exception {
+        final String[] types = {"text", "tel", "number", "search", "password", "email", "url", "date", "time"};
+
+        for (final String type : types) {
+            final String html = DOCTYPE_HTML
+                + "<html><body>\n"
+                + "<input type='" + type + "' id='t'>\n"
+                + "<script>\n"
+                + "  document.getElementById('t').addEventListener('input', function() {\n"
+                + "    document.title += 'input';\n"
+                + "  });\n"
+                + "</script>\n"
+                + "</body></html>";
+            final HtmlPage page = loadPage(html);
+            page.getHtmlElementById("t").type("ab");
+            assertEquals("input event for type=" + type, "inputinput", page.getTitleText());
+        }
+    }
 }


### PR DESCRIPTION
This PR does the following
--------------------------

Fix `HtmlElement` to correctly fire the `input` event when typing into `<input>` elements with `type=email`, `type=url`, `type=date`, or `type=time`.

Problem
-------

When calling `HtmlElement.type()` on input elements with `type=email`, `type=url`, `type=date`, or `type=time`, the `input` event is never fired.

The code that dispatches the event uses an explicit list of `instanceof` checks (`HtmlTextInput`, `HtmlTelInput`, `HtmlNumberInput`, `HtmlSearchInput`, `HtmlPasswordInput`) that does not include all text-like input types.
