### PR TITLE
HtmlPage: fix a bug where async script may not be executed

### DIFF
--- a/src/main/java/org/htmlunit/html/HtmlPage.java
+++ b/src/main/java/org/htmlunit/html/HtmlPage.java
@@ -260,6 +260,8 @@ public class HtmlPage extends SgmlPage {
             executeEventHandlersIfNeeded(Event.TYPE_READY_STATE_CHANGE);
         }
 
+        executePostponedScriptsIfNeeded();
+
         executeDeferredScriptsIfNeeded();
 
         executeEventHandlersIfNeeded(Event.TYPE_DOM_DOCUMENT_LOADED);
@@ -1475,6 +1477,13 @@ public class HtmlPage extends SgmlPage {
             return metaTags.get(0).getContentAttribute().trim();
         }
         return getWebResponse().getResponseHeaderValue("Refresh");
+    }
+
+    private void executePostponedScriptsIfNeeded() {
+        if (!getWebClient().isJavaScriptEnabled()) {
+            return;
+        }
+        getWebClient().getJavaScriptEngine().processPostponedActions();
     }
 
     /**

--- a/src/test/java/org/htmlunit/html/HtmlPageTest.java
+++ b/src/test/java/org/htmlunit/html/HtmlPageTest.java
@@ -1973,4 +1973,25 @@ public class HtmlPageTest extends SimpleWebTestCase {
         page = loadPage(getBrowserVersion(), html, null, new URL(URL_FIRST + path));
         assertEquals(URL_FIRST.toExternalForm() + path, page.getBaseURL().toExternalForm());
     }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void asyncScriptExecutedWithoutEventHandlers() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script async src='async.js'></script>\n"
+            + "</head><body></body></html>";
+
+        final WebClient client = getWebClient();
+        final MockWebConnection webConnection = new MockWebConnection();
+        webConnection.setDefaultResponse(html);
+        webConnection.setResponse(new URL(URL_FIRST, "async.js"),
+                "document.title = 'async-executed';", "text/javascript");
+        client.setWebConnection(webConnection);
+
+        final HtmlPage page = client.getPage(URL_FIRST);
+        assertEquals("async-executed", page.getTitleText());
+    }
 }


### PR DESCRIPTION
This PR does the following
--------------------------

Fix `HtmlPage` to flush postponed actions (including async scripts) before executing deferred scripts during page initialization.

Problem
-------

Since [bca4c02](https://github.com/HtmlUnit/htmlunit/commit/bca4c02b940881ea1a032cbd3a18d50a6098c99e), async `<script>` tags are added to the postponed actions queue via `engine.addPostponedAction()` instead of `page.addAfterLoadAction()`.

The postponed actions queue is normally drained after synchronous script execution or event dispatch.
However, if a page has an async script with no subsequent synchronous scripts and no event handlers, the async script is silently ignored.

```html
<html>
<head>
  <script async src="async.js"></script>
</head>
</html>
```