### PR TITLE
HTMLAreaElement: add URL properties

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLAnchorElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLAnchorElement.java
@@ -241,11 +241,7 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxGetter
     public String getSearch() {
         try {
-            final String query = getUrl().getQuery();
-            if (query == null) {
-                return "";
-            }
-            return "?" + query;
+            return HTMLHyperlinkElementUtils.getSearch(getUrl());
         }
         catch (final MalformedURLException e) {
             return "";
@@ -261,20 +257,7 @@ public class HTMLAnchorElement extends HTMLElement {
      */
     @JsxSetter
     public void setSearch(final String search) throws Exception {
-        final String query;
-        if (search == null
-                || StringUtils.isEmptyString(search)
-                || StringUtils.equalsChar('?', search)) {
-            query = null;
-        }
-        else if (search.charAt(0) == '?') {
-            query = search.substring(1);
-        }
-        else {
-            query = search;
-        }
-
-        setUrl(UrlUtils.getUrlWithNewQuery(getUrl(), query));
+        setUrl(HTMLHyperlinkElementUtils.setSearch(getUrl(), search));
     }
 
     /**
@@ -285,11 +268,7 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxGetter
     public String getHash() {
         try {
-            final String hash = getUrl().getRef();
-            if (hash == null) {
-                return "";
-            }
-            return "#" + hash;
+            return HTMLHyperlinkElementUtils.getHash(getUrl());
         }
         catch (final MalformedURLException e) {
             return "";
@@ -304,7 +283,7 @@ public class HTMLAnchorElement extends HTMLElement {
      */
     @JsxSetter
     public void setHash(final String hash) throws Exception {
-        setUrl(UrlUtils.getUrlWithNewRef(getUrl(), hash));
+        setUrl(HTMLHyperlinkElementUtils.setHash(getUrl(), hash));
     }
 
     /**
@@ -319,7 +298,7 @@ public class HTMLAnchorElement extends HTMLElement {
             final int port = url.getPort();
             final String host = url.getHost();
 
-            if (port == -1 || isDefaultPort(url.getProtocol(), port)) {
+            if (port == -1 || HTMLHyperlinkElementUtils.isDefaultPort(url.getProtocol(), port)) {
                 return host;
             }
             return host + ":" + port;
@@ -337,19 +316,7 @@ public class HTMLAnchorElement extends HTMLElement {
      */
     @JsxSetter
     public void setHost(final String host) throws Exception {
-        final String hostname;
-        final int port;
-        final int index = host.indexOf(':');
-        if (index != -1) {
-            hostname = host.substring(0, index);
-            port = Integer.parseInt(host.substring(index + 1));
-        }
-        else {
-            hostname = host;
-            port = -1;
-        }
-        final URL url = UrlUtils.getUrlWithNewHostAndPort(getUrl(), hostname, port);
-        setUrl(url);
+        setUrl(HTMLHyperlinkElementUtils.setHost(getUrl(), host));
     }
 
     /**
@@ -360,7 +327,7 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxGetter
     public String getHostname() {
         try {
-            return UrlUtils.encodeAnchor(getUrl().getHost());
+            return HTMLHyperlinkElementUtils.getHostname(getUrl());
         }
         catch (final MalformedURLException e) {
             return "";
@@ -426,7 +393,7 @@ public class HTMLAnchorElement extends HTMLElement {
      */
     @JsxSetter
     public void setPathname(final String pathname) throws Exception {
-        setUrl(UrlUtils.getUrlWithNewPath(getUrl(), pathname));
+        setUrl(HTMLHyperlinkElementUtils.setPathname(getUrl(), pathname));
     }
 
     /**
@@ -439,7 +406,7 @@ public class HTMLAnchorElement extends HTMLElement {
         try {
             final URL url = getUrl();
             final int port = url.getPort();
-            if (port == -1 || isDefaultPort(url.getProtocol(), port)) {
+            if (port == -1 || HTMLHyperlinkElementUtils.isDefaultPort(url.getProtocol(), port)) {
                 return "";
             }
             return Integer.toString(port);
@@ -459,7 +426,7 @@ public class HTMLAnchorElement extends HTMLElement {
     public void setPort(final String port) throws Exception {
         final URL url = getUrl();
         final int newPort = Integer.parseInt(port);
-        if (isDefaultPort(url.getProtocol(), newPort)) {
+        if (HTMLHyperlinkElementUtils.isDefaultPort(url.getProtocol(), newPort)) {
             setUrl(UrlUtils.getUrlWithNewPort(url, -1));
         }
         else {
@@ -503,25 +470,9 @@ public class HTMLAnchorElement extends HTMLElement {
      */
     @JsxSetter
     public void setProtocol(final String protocol) throws Exception {
-        if (protocol.isEmpty()) {
-            return;
-        }
-
-        final String bareProtocol = StringUtils.substringBefore(protocol, ":").trim();
-        if (!UrlUtils.isValidScheme(bareProtocol)) {
-            return;
-        }
-        if (!UrlUtils.isSpecialScheme(bareProtocol)) {
-            return;
-        }
-
-        try {
-            URL url = UrlUtils.getUrlWithNewProtocol(getUrl(), bareProtocol);
-            url = UrlUtils.removeRedundantPort(url);
-            setUrl(url);
-        }
-        catch (final MalformedURLException ignored) {
-            // ignore
+        final URL result = HTMLHyperlinkElementUtils.setProtocol(getUrl(), protocol);
+        if (result != null) {
+            setUrl(result);
         }
     }
 
@@ -661,11 +612,7 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxGetter
     public String getUsername() {
         try {
-            final String userInfo = getUrl().getUserInfo();
-            if (userInfo == null) {
-                return "";
-            }
-            return org.apache.commons.lang3.StringUtils.substringBefore(userInfo, ':');
+            return HTMLHyperlinkElementUtils.getUsername(getUrl());
         }
         catch (final MalformedURLException e) {
             return "";
@@ -700,11 +647,7 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxGetter
     public String getPassword() {
         try {
-            final String userName = getUrl().getUserInfo();
-            if (userName == null) {
-                return "";
-            }
-            return StringUtils.substringAfter(userName, ":");
+            return HTMLHyperlinkElementUtils.getPassword(getUrl());
         }
         catch (final MalformedURLException e) {
             return "";
@@ -820,16 +763,5 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxSetter
     public void setRelList(final Object rel) {
         setRel(JavaScriptEngine.toString(rel));
-    }
-
-    /**
-     * Checks whether the given port is the default port for the protocol.
-     * @param protocol the protocol (e.g. {@code "http"}, {@code "https"})
-     * @param port the port number
-     * @return {@code true} if the port is the default for the protocol
-     */
-    private static boolean isDefaultPort(final String protocol, final int port) {
-        return ("http".equals(protocol) && port == 80)
-                || ("https".equals(protocol) && port == 443);
     }
 }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLAnchorElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLAnchorElement.java
@@ -55,6 +55,7 @@ import org.htmlunit.util.UrlUtils;
  * @author Sudhan Moghe
  * @author Daniel Gredler
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 @JsxClass(domClass = HtmlAnchor.class)
 public class HTMLAnchorElement extends HTMLElement {
@@ -318,7 +319,7 @@ public class HTMLAnchorElement extends HTMLElement {
             final int port = url.getPort();
             final String host = url.getHost();
 
-            if (port == -1) {
+            if (port == -1 || isDefaultPort(url.getProtocol(), port)) {
                 return host;
             }
             return host + ":" + port;
@@ -436,8 +437,9 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxGetter
     public String getPort() {
         try {
-            final int port = getUrl().getPort();
-            if (port == -1) {
+            final URL url = getUrl();
+            final int port = url.getPort();
+            if (port == -1 || isDefaultPort(url.getProtocol(), port)) {
                 return "";
             }
             return Integer.toString(port);
@@ -455,7 +457,14 @@ public class HTMLAnchorElement extends HTMLElement {
      */
     @JsxSetter
     public void setPort(final String port) throws Exception {
-        setUrl(UrlUtils.getUrlWithNewPort(getUrl(), Integer.parseInt(port)));
+        final URL url = getUrl();
+        final int newPort = Integer.parseInt(port);
+        if (isDefaultPort(url.getProtocol(), newPort)) {
+            setUrl(UrlUtils.getUrlWithNewPort(url, -1));
+        }
+        else {
+            setUrl(UrlUtils.getUrlWithNewPort(url, newPort));
+        }
     }
 
     /**
@@ -811,5 +820,16 @@ public class HTMLAnchorElement extends HTMLElement {
     @JsxSetter
     public void setRelList(final Object rel) {
         setRel(JavaScriptEngine.toString(rel));
+    }
+
+    /**
+     * Checks whether the given port is the default port for the protocol.
+     * @param protocol the protocol (e.g. {@code "http"}, {@code "https"})
+     * @param port the port number
+     * @return {@code true} if the port is the default for the protocol
+     */
+    private static boolean isDefaultPort(final String protocol, final int port) {
+        return ("http".equals(protocol) && port == 80)
+                || ("https".equals(protocol) && port == 443);
     }
 }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLAreaElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLAreaElement.java
@@ -17,13 +17,19 @@ package org.htmlunit.javascript.host.html;
 import static org.htmlunit.BrowserVersionFeatures.JS_AREA_WITHOUT_HREF_FOCUSABLE;
 import static org.htmlunit.html.DomElement.ATTRIBUTE_NOT_DEFINED;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.htmlunit.html.HtmlArea;
 import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlPage;
 import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
 import org.htmlunit.javascript.configuration.JsxGetter;
 import org.htmlunit.javascript.configuration.JsxSetter;
 import org.htmlunit.javascript.host.dom.DOMTokenList;
+import org.htmlunit.util.StringUtils;
+import org.htmlunit.util.UrlUtils;
 
 /**
  * The JavaScript object {@code HTMLAreaElement}.
@@ -31,6 +37,7 @@ import org.htmlunit.javascript.host.dom.DOMTokenList;
  * @author Ahmed Ashour
  * @author Ronald Brill
  * @author Frank Danek
+ * @author Lai Quang Duong
  */
 @JsxClass(domClass = HtmlArea.class)
 public class HTMLAreaElement extends HTMLElement {
@@ -145,4 +152,335 @@ public class HTMLAreaElement extends HTMLElement {
         getDomNodeOrDie().setAttribute("coords", coords);
     }
 
+    /**
+     * Returns the {@code href} property.
+     * @return the {@code href} property
+     */
+    @JsxGetter
+    public String getHref() {
+        final HtmlArea area = (HtmlArea) getDomNodeOrDie();
+        final String hrefAttr = area.getHrefAttribute();
+
+        if (ATTRIBUTE_NOT_DEFINED == hrefAttr) {
+            return "";
+        }
+
+        try {
+            return getUrl().toString();
+        }
+        catch (final MalformedURLException e) {
+            return hrefAttr;
+        }
+    }
+
+    /**
+     * Sets the {@code href} property.
+     * @param href the {@code href} value
+     */
+    @JsxSetter
+    public void setHref(final String href) {
+        getDomNodeOrDie().setAttribute("href", href);
+    }
+
+    /**
+     * Returns the {@code protocol} property.
+     * @return the {@code protocol} property
+     */
+    @JsxGetter
+    public String getProtocol() {
+        try {
+            return getUrl().getProtocol() + ":";
+        }
+        catch (final MalformedURLException e) {
+            return ":";
+        }
+    }
+
+    /**
+     * Sets the {@code protocol} property.
+     * @param protocol the {@code protocol} value
+     * @throws Exception if an error occurs
+     */
+    @JsxSetter
+    public void setProtocol(final String protocol) throws Exception {
+        final URL result = HTMLHyperlinkElementUtils.setProtocol(getUrl(), protocol);
+        if (result != null) {
+            setUrl(result);
+        }
+    }
+
+    /**
+     * Returns the {@code hostname} property.
+     * @return the {@code hostname} property
+     */
+    @JsxGetter
+    public String getHostname() {
+        try {
+            return HTMLHyperlinkElementUtils.getHostname(getUrl());
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code hostname} property.
+     * @param hostname the {@code hostname} value
+     * @throws Exception if an error occurs
+     */
+    @JsxSetter
+    public void setHostname(final String hostname) throws Exception {
+        if (!StringUtils.isEmptyOrNull(hostname)) {
+            setUrl(UrlUtils.getUrlWithNewHost(getUrl(), hostname));
+        }
+    }
+
+    /**
+     * Returns the {@code host} property.
+     * @return the {@code host} property
+     */
+    @JsxGetter
+    public String getHost() {
+        try {
+            final URL url = getUrl();
+            final int port = url.getPort();
+            final String host = url.getHost();
+
+            if (port == -1 || HTMLHyperlinkElementUtils.isDefaultPort(url.getProtocol(), port)) {
+                return host;
+            }
+            return host + ":" + port;
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code host} property.
+     * @param host the {@code host} value
+     * @throws Exception if an error occurs
+     */
+    @JsxSetter
+    public void setHost(final String host) throws Exception {
+        setUrl(HTMLHyperlinkElementUtils.setHost(getUrl(), host));
+    }
+
+    /**
+     * Returns the {@code port} property.
+     * @return the {@code port} property
+     */
+    @JsxGetter
+    public String getPort() {
+        try {
+            final URL url = getUrl();
+            final int port = url.getPort();
+            if (port == -1 || HTMLHyperlinkElementUtils.isDefaultPort(url.getProtocol(), port)) {
+                return "";
+            }
+            return Integer.toString(port);
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code port} property.
+     * @param port the {@code port} value
+     * @throws Exception if an error occurs
+     */
+    @JsxSetter
+    public void setPort(final String port) throws Exception {
+        final URL url = getUrl();
+        final int newPort = Integer.parseInt(port);
+        if (HTMLHyperlinkElementUtils.isDefaultPort(url.getProtocol(), newPort)) {
+            setUrl(UrlUtils.getUrlWithNewPort(url, -1));
+        }
+        else {
+            setUrl(UrlUtils.getUrlWithNewPort(url, newPort));
+        }
+    }
+
+    /**
+     * Returns the {@code pathname} property.
+     * @return the {@code pathname} property
+     */
+    @JsxGetter
+    public String getPathname() {
+        try {
+            return getUrl().getPath();
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code pathname} property.
+     * @param pathname the {@code pathname} value
+     * @throws Exception if an error occurs
+     */
+    @JsxSetter
+    public void setPathname(final String pathname) throws Exception {
+        setUrl(HTMLHyperlinkElementUtils.setPathname(getUrl(), pathname));
+    }
+
+    /**
+     * Returns the {@code search} property.
+     * @return the {@code search} property
+     */
+    @JsxGetter
+    public String getSearch() {
+        try {
+            return HTMLHyperlinkElementUtils.getSearch(getUrl());
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code search} property.
+     * @param search the {@code search} value
+     * @throws Exception if an error occurs
+     */
+    @JsxSetter
+    public void setSearch(final String search) throws Exception {
+        setUrl(HTMLHyperlinkElementUtils.setSearch(getUrl(), search));
+    }
+
+    /**
+     * Returns the {@code hash} property.
+     * @return the {@code hash} property
+     */
+    @JsxGetter
+    public String getHash() {
+        try {
+            return HTMLHyperlinkElementUtils.getHash(getUrl());
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code hash} property.
+     * @param hash the {@code hash} value
+     * @throws Exception if an error occurs
+     */
+    @JsxSetter
+    public void setHash(final String hash) throws Exception {
+        setUrl(HTMLHyperlinkElementUtils.setHash(getUrl(), hash));
+    }
+
+    /**
+     * Returns the {@code origin} property.
+     * @return the {@code origin} property
+     */
+    @JsxGetter
+    public String getOrigin() {
+        if (!getDomNodeOrDie().hasAttribute("href")) {
+            return "";
+        }
+
+        try {
+            return getUrl().getProtocol() + "://" + getHost();
+        }
+        catch (final Exception e) {
+            return "";
+        }
+    }
+
+    /**
+     * Returns the {@code username} property.
+     * @return the {@code username} property
+     */
+    @JsxGetter
+    public String getUsername() {
+        try {
+            return HTMLHyperlinkElementUtils.getUsername(getUrl());
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code username} property.
+     * @param username the {@code username} value
+     */
+    @JsxSetter
+    public void setUsername(final String username) {
+        try {
+            final HtmlArea area = (HtmlArea) getDomNodeOrDie();
+            final String href = area.getHrefAttribute();
+            if (ATTRIBUTE_NOT_DEFINED == href) {
+                return;
+            }
+
+            final URL url = ((HtmlPage) area.getPage()).getFullyQualifiedUrl(href);
+            setUrl(UrlUtils.getUrlWithNewUserName(url, username));
+        }
+        catch (final MalformedURLException ignored) {
+            // ignore
+        }
+    }
+
+    /**
+     * Returns the {@code password} property.
+     * @return the {@code password} property
+     */
+    @JsxGetter
+    public String getPassword() {
+        try {
+            return HTMLHyperlinkElementUtils.getPassword(getUrl());
+        }
+        catch (final MalformedURLException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Sets the {@code password} property.
+     * @param password the {@code password} value
+     */
+    @JsxSetter
+    public void setPassword(final String password) {
+        try {
+            final HtmlArea area = (HtmlArea) getDomNodeOrDie();
+            final String href = area.getHrefAttribute();
+            if (ATTRIBUTE_NOT_DEFINED == href) {
+                return;
+            }
+
+            final URL url = ((HtmlPage) area.getPage()).getFullyQualifiedUrl(href);
+            setUrl(UrlUtils.getUrlWithNewUserPassword(url, password));
+        }
+        catch (final MalformedURLException ignored) {
+            // ignore
+        }
+    }
+
+    /**
+     * Returns this area's current URL.
+     * @return this area's current URL
+     * @throws MalformedURLException if an error occurs
+     */
+    private URL getUrl() throws MalformedURLException {
+        final HtmlArea area = (HtmlArea) getDomNodeOrDie();
+        final String href = area.getHrefAttribute();
+        if (ATTRIBUTE_NOT_DEFINED == href) {
+            throw new MalformedURLException("no href attribute");
+        }
+        return ((HtmlPage) area.getPage()).getFullyQualifiedUrl(href);
+    }
+
+    /**
+     * Sets the {@code href} attribute of this area to the specified URL.
+     * @param url the new value of the {@code href} attribute
+     */
+    private void setUrl(final URL url) {
+        getDomNodeOrDie().setAttribute("href", url.toString());
+    }
 }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLHyperlinkElementUtils.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLHyperlinkElementUtils.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2002-2026 Gargoyle Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit.javascript.host.html;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.htmlunit.util.StringUtils;
+import org.htmlunit.util.UrlUtils;
+
+/**
+ * Implementation of the {@code HTMLHyperlinkElementUtils} mixin.
+ * Provides URL decomposition property logic
+ * @see <a href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils">
+ *      HTMLHyperlinkElementUtils</a>
+ */
+final class HTMLHyperlinkElementUtils {
+
+    /**
+     * Returns the {@code search} component of the URL.
+     * @param url the URL
+     * @return the query string prefixed with {@code ?}, or empty string if no query
+     */
+    static String getSearch(final URL url) {
+        final String query = url.getQuery();
+        if (query == null) {
+            return "";
+        }
+        return "?" + query;
+    }
+
+    /**
+     * Returns a new URL with the {@code search} component set.
+     * @param url the current URL
+     * @param search the new search value (with or without leading {@code ?})
+     * @return the new URL
+     * @throws MalformedURLException if an error occurs
+     */
+    static URL setSearch(final URL url, final String search) throws MalformedURLException {
+        final String query;
+        if (search == null
+                || StringUtils.isEmptyString(search)
+                || StringUtils.equalsChar('?', search)) {
+            query = null;
+        }
+        else if (search.charAt(0) == '?') {
+            query = search.substring(1);
+        }
+        else {
+            query = search;
+        }
+        return UrlUtils.getUrlWithNewQuery(url, query);
+    }
+
+    /**
+     * Returns the {@code hash} component of the URL.
+     * @param url the URL
+     * @return the fragment prefixed with {@code #}, or empty string if no fragment
+     */
+    static String getHash(final URL url) {
+        final String hash = url.getRef();
+        if (hash == null) {
+            return "";
+        }
+        return "#" + hash;
+    }
+
+    /**
+     * Returns a new URL with the {@code hash} component set.
+     * @param url the current URL
+     * @param hash the new hash value
+     * @return the new URL
+     * @throws MalformedURLException if an error occurs
+     */
+    static URL setHash(final URL url, final String hash) throws MalformedURLException {
+        return UrlUtils.getUrlWithNewRef(url, hash);
+    }
+
+    /**
+     * Returns the {@code hostname} component of the URL.
+     * @param url the URL
+     * @return the hostname
+     */
+    static String getHostname(final URL url) {
+        return UrlUtils.encodeAnchor(url.getHost());
+    }
+
+    /**
+     * Returns a new URL with the {@code host} component set.
+     * Parses the host string for an optional {@code :port} suffix.
+     * @param url the current URL
+     * @param host the new host value (e.g. {@code "example.com:8080"})
+     * @return the new URL
+     * @throws MalformedURLException if an error occurs
+     */
+    static URL setHost(final URL url, final String host) throws MalformedURLException {
+        final String hostname;
+        final int port;
+        final int index = host.indexOf(':');
+        if (index != -1) {
+            hostname = host.substring(0, index);
+            port = Integer.parseInt(host.substring(index + 1));
+        }
+        else {
+            hostname = host;
+            port = -1;
+        }
+        return UrlUtils.getUrlWithNewHostAndPort(url, hostname, port);
+    }
+
+    /**
+     * Returns a new URL with the {@code protocol} set, or {@code null}
+     * if the protocol is invalid or should not be applied.
+     * @param url the current URL
+     * @param protocol the new protocol value (with or without trailing {@code :})
+     * @return the new URL, or {@code null} if the protocol is invalid
+     */
+    static URL setProtocol(final URL url, final String protocol) {
+        if (protocol.isEmpty()) {
+            return null;
+        }
+
+        final String bareProtocol = StringUtils.substringBefore(protocol, ":").trim();
+        if (!UrlUtils.isValidScheme(bareProtocol)) {
+            return null;
+        }
+        if (!UrlUtils.isSpecialScheme(bareProtocol)) {
+            return null;
+        }
+
+        try {
+            URL result = UrlUtils.getUrlWithNewProtocol(url, bareProtocol);
+            result = UrlUtils.removeRedundantPort(result);
+            return result;
+        }
+        catch (final MalformedURLException ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns a new URL with the {@code pathname} set.
+     * @param url the current URL
+     * @param pathname the new pathname value
+     * @return the new URL
+     * @throws MalformedURLException if an error occurs
+     */
+    static URL setPathname(final URL url, final String pathname) throws MalformedURLException {
+        return UrlUtils.getUrlWithNewPath(url, pathname);
+    }
+
+    /**
+     * Returns the {@code username} component of the URL.
+     * @param url the URL
+     * @return the username, or empty string if no user info
+     */
+    static String getUsername(final URL url) {
+        final String userInfo = url.getUserInfo();
+        if (userInfo == null) {
+            return "";
+        }
+        return StringUtils.substringBefore(userInfo, ":");
+    }
+
+    /**
+     * Returns the {@code password} component of the URL.
+     * @param url the URL
+     * @return the password, or empty string if no user info
+     */
+    static String getPassword(final URL url) {
+        final String userInfo = url.getUserInfo();
+        if (userInfo == null) {
+            return "";
+        }
+        return StringUtils.substringAfter(userInfo, ":");
+    }
+
+    /**
+     * Checks whether the given port is the default port for the protocol.
+     * @param protocol the protocol (e.g. {@code "http"}, {@code "https"})
+     * @param port the port number
+     * @return {@code true} if the port is the default for the protocol
+     */
+    static boolean isDefaultPort(final String protocol, final int port) {
+        return ("http".equals(protocol) && port == 80)
+                || ("https".equals(protocol) && port == 443);
+    }
+}

--- a/src/test/java/org/htmlunit/javascript/host/html/HTMLAnchorElement2Test.java
+++ b/src/test/java/org/htmlunit/javascript/host/html/HTMLAnchorElement2Test.java
@@ -1596,4 +1596,43 @@ public class HTMLAnchorElement2Test extends WebDriverTestCase {
         expandExpectedAlertsVariables("" + PORT);
         loadPageVerifyTitle2(html);
     }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"", "example.com", "", "example.com", "https://example.com",
+             "", "example.com", "https://example.com"})
+    public void defaultPortStripping() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            // http:80 should be stripped
+            + "    var a = document.getElementById('a1');\n"
+            + "    log(a.port);\n"
+            + "    log(a.hostname);\n"
+            // https:443 should be stripped
+            + "    var b = document.getElementById('a2');\n"
+            + "    log(b.port);\n"
+            + "    log(b.host);\n"
+            + "    log(b.origin);\n"
+            // setPort to default should strip
+            + "    var c = document.getElementById('a3');\n"
+            + "    c.port = '443';\n"
+            + "    log(c.port);\n"
+            + "    log(c.host);\n"
+            + "    log(c.origin);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "  <a id='a1' href='http://example.com:80/path'>link 1</a>\n"
+            + "  <a id='a2' href='https://example.com:443/path'>link 2</a>\n"
+            + "  <a id='a3' href='https://example.com:9000/path'>link 3</a>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
 }

--- a/src/test/java/org/htmlunit/javascript/host/html/HTMLAnchorElementTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/html/HTMLAnchorElementTest.java
@@ -141,9 +141,9 @@ public class HTMLAnchorElementTest extends SimpleWebTestCase {
             + "</body></html>";
         final HtmlPage page = loadPage(getBrowserVersion(), html, null, URL_GARGOYLE);
         HtmlAnchor link = page.getAnchors().get(0);
-        assertEquals("http://www.gargoylesoftware.com:80/foo.html#O", link.getHrefAttribute());
+        assertEquals("http://www.gargoylesoftware.com/foo.html#O", link.getHrefAttribute());
         link = page.getAnchors().get(1);
-        assertEquals("http://www.gargoylesoftware.com:8080/foo.html#O", link.getHrefAttribute());
+        assertEquals("http://www.gargoylesoftware.com/foo.html#O", link.getHrefAttribute());
     }
 
     /**
@@ -198,7 +198,7 @@ public class HTMLAnchorElementTest extends SimpleWebTestCase {
         link = page.getAnchors().get(1);
         assertEquals("http://www.gargoylesoftware.commotion/foo.html#O", link.getHrefAttribute());
         link = page.getAnchors().get(2);
-        assertEquals("http://www.gargoylesoftware.com:8080/foo.html#O", link.getHrefAttribute());
+        assertEquals("http://www.gargoylesoftware.com80/foo.html#O", link.getHrefAttribute());
         link = page.getAnchors().get(3);
         assertEquals("http://www.gargoylesoftware.com/foo.html#O", link.getHrefAttribute());
     }

--- a/src/test/java/org/htmlunit/javascript/host/html/HTMLAreaElementTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/html/HTMLAreaElementTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
  * @author Ahmed Ashour
  * @author Ronald Brill
  * @author Frank Danek
+ * @author Lai Quang Duong
  */
 public class HTMLAreaElementTest extends WebDriverTestCase {
 
@@ -186,6 +187,179 @@ public class HTMLAreaElementTest extends WebDriverTestCase {
             + "log(a2.rel);\n"
 
             + "</script></body></html>";
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"https:", "example.com", "8443", "/app/index.html", "?q=test", "#section",
+             "example.com:8443", "https://example.com:8443", "user", "pass"})
+    public void urlProperties() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    var a = document.getElementById('a1');\n"
+            + "    log(a.protocol);\n"
+            + "    log(a.hostname);\n"
+            + "    log(a.port);\n"
+            + "    log(a.pathname);\n"
+            + "    log(a.search);\n"
+            + "    log(a.hash);\n"
+            + "    log(a.host);\n"
+            + "    log(a.origin);\n"
+            + "    log(a.username);\n"
+            + "    log(a.password);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "  <map><area id='a1'"
+            + " href='https://user:pass@example.com:8443/app/index.html?q=test#section'"
+            + " shape='rect' coords='0,0,1,1'/></map>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"", ":", "", "", "", "", "", ""})
+    public void noHrefAttribute() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    var a = document.getElementById('a1');\n"
+            + "    log(a.href);\n"
+            + "    log(a.protocol);\n"
+            + "    log(a.hostname);\n"
+            + "    log(a.port);\n"
+            + "    log(a.pathname);\n"
+            + "    log(a.search);\n"
+            + "    log(a.hash);\n"
+            + "    log(a.origin);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "  <map><area id='a1' shape='rect' coords='0,0,1,1'/></map>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"", "example.com",
+             "", "example.com", "https://example.com"})
+    public void defaultPortStripping() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            // http:80
+            + "    var a = document.getElementById('a1');\n"
+            + "    log(a.port);\n"
+            + "    log(a.host);\n"
+            // https:443
+            + "    var b = document.getElementById('a2');\n"
+            + "    log(b.port);\n"
+            + "    log(b.host);\n"
+            + "    log(b.origin);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "  <map>\n"
+            + "    <area id='a1' href='http://example.com:80/path' shape='rect' coords='0,0,1,1'/>\n"
+            + "    <area id='a2' href='https://example.com:443/path' shape='rect' coords='0,0,1,1'/>\n"
+            + "  </map>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"http:", "http://user:pass@example.com:8080/path/to/page?query=value#fragment",
+             "9000", "example.com:9000",
+             "", "example.com",
+             "other.com",
+             "new.com:3000", "3000",
+             "/new/path",
+             "?new=search", "?no=prefix",
+             "#section", "#prefixed",
+             "newuser", "secret",
+             "https://final.com/done"})
+    public void urlSetters() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function test() {\n"
+            + "    var a = document.getElementById('a1');\n"
+            // setProtocol
+            + "    a.protocol = 'http';\n"
+            + "    log(a.protocol);\n"
+            + "    log(a.href);\n"
+            // setPort non-default
+            + "    a.port = '9000';\n"
+            + "    log(a.port);\n"
+            + "    log(a.host);\n"
+            // setPort default (http:80) - should strip
+            + "    a.port = '80';\n"
+            + "    log(a.port);\n"
+            + "    log(a.host);\n"
+            // setHostname
+            + "    a.hostname = 'other.com';\n"
+            + "    log(a.hostname);\n"
+            // setHost with port
+            + "    a.host = 'new.com:3000';\n"
+            + "    log(a.host);\n"
+            + "    log(a.port);\n"
+            // setPathname
+            + "    a.pathname = '/new/path';\n"
+            + "    log(a.pathname);\n"
+            // setSearch with and without ?
+            + "    a.search = '?new=search';\n"
+            + "    log(a.search);\n"
+            + "    a.search = 'no=prefix';\n"
+            + "    log(a.search);\n"
+            // setHash with and without #
+            + "    a.hash = 'section';\n"
+            + "    log(a.hash);\n"
+            + "    a.hash = '#prefixed';\n"
+            + "    log(a.hash);\n"
+            // setUsername
+            + "    a.username = 'newuser';\n"
+            + "    log(a.username);\n"
+            // setPassword
+            + "    a.password = 'secret';\n"
+            + "    log(a.password);\n"
+            // setHref
+            + "    a.href = 'https://final.com/done';\n"
+            + "    log(a.href);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</head>\n"
+            + "<body onload='test()'>\n"
+            + "  <map><area id='a1'"
+            + " href='https://user:pass@example.com:8080/path/to/page?query=value#fragment'"
+            + " shape='rect' coords='0,0,1,1'/></map>\n"
+            + "</body></html>";
+
         loadPageVerifyTitle2(html);
     }
 


### PR DESCRIPTION
### This PR does the following

Extracts shared URL decomposition logic into a new `HTMLHyperlinkElementUtils` utility class and refactors both `HTMLAnchorElement` and `HTMLAreaElement` to delegate to it.