### PR TITLE
DefaultPageCreator: force content sniffing for */* content type

### DIFF
--- a/src/main/java/org/htmlunit/DefaultPageCreator.java
+++ b/src/main/java/org/htmlunit/DefaultPageCreator.java
@@ -155,7 +155,7 @@ public class DefaultPageCreator implements PageCreator, Serializable {
      */
     public static PageType determinePageType(final WebResponse webResponse) throws IOException {
         final String contentType = webResponse.getContentType();
-        if (!StringUtils.isEmptyOrNull(contentType)) {
+        if (!StringUtils.isEmptyOrNull(contentType) && !"*/*".equals(contentType)) {
             return determinePageType(contentType);
         }
 

--- a/src/test/java/org/htmlunit/DefaultPageCreatorTest.java
+++ b/src/test/java/org/htmlunit/DefaultPageCreatorTest.java
@@ -38,6 +38,7 @@ import jakarta.servlet.http.HttpServletResponse;
  * @author Marc Guillemot
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 public class DefaultPageCreatorTest extends WebServerTestCase {
 
@@ -374,6 +375,32 @@ public class DefaultPageCreatorTest extends WebServerTestCase {
         protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
             final Writer writer = response.getWriter();
             writer.write(DOCTYPE_HTML + "<html><head><title>\u00d3</title></head><body></body></html>");
+        }
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void wildcardContentType() throws Exception {
+        final Map<String, Class<? extends Servlet>> servlets = new HashMap<>();
+        servlets.put("/test", WildcardContentTypeServlet.class);
+        startWebServer("./", servlets);
+
+        final WebClient client = getWebClient();
+        assertTrue(client.getPage(URL_FIRST + "test") instanceof HtmlPage);
+    }
+
+    /**
+     * Servlet for {@link #wildcardContentType()}.
+     */
+    public static class WildcardContentTypeServlet extends HttpServlet {
+        /** {@inheritDoc} */
+        @Override
+        protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+            response.setContentType("*/*");
+            final Writer writer = response.getWriter();
+            writer.write("<html><head></head><body>Hello World</body></html>");
         }
     }
 


### PR DESCRIPTION
### This PR does the following

Force content sniffing for `*/*` response content type to make it behaves same as real browser, instead of returning `UnexpectedPage`.