### PR TITLE
Update page url when hash changes

### DIFF
--- a/src/main/java/org/htmlunit/WebClient.java
+++ b/src/main/java/org/htmlunit/WebClient.java
@@ -1386,16 +1386,16 @@ public class WebClient implements Serializable, AutoCloseable {
 
     private static WebResponse makeWebResponseForAboutUrl(final WebRequest webRequest) throws MalformedURLException {
         final URL url = webRequest.getUrl();
-        final String urlString = url.toExternalForm();
-        if (UrlUtils.ABOUT_BLANK.equalsIgnoreCase(urlString)) {
-            return new StringWebResponse("", UrlUtils.URL_ABOUT_BLANK);
+        if (UrlUtils.ABOUT.equals(url.getProtocol())) {
+            if ("blank".equalsIgnoreCase(url.getPath())) {
+                if (url.getRef() == null && url.getQuery() == null) {
+                    return new StringWebResponse("", UrlUtils.URL_ABOUT_BLANK);
+                }
+                return new StringWebResponse("", url);
+            }
         }
 
-        final String urlWithoutQuery = StringUtils.substringBefore(urlString, "?");
-        if (!"blank".equalsIgnoreCase(StringUtils.substringAfter(urlWithoutQuery, UrlUtils.ABOUT_SCHEME))) {
-            throw new MalformedURLException(url + " is not supported, only about:blank is supported at the moment.");
-        }
-        return new StringWebResponse("", url);
+        throw new MalformedURLException(url + " is not supported, only about:blank is supported at the moment.");
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/Location.java
+++ b/src/main/java/org/htmlunit/javascript/host/Location.java
@@ -441,10 +441,18 @@ public class Location extends HtmlUnitScriptable {
         final boolean hasChanged = hash != null && !hash.equals(hash_);
         hash_ = hash;
 
-        if (triggerHashChanged && hasChanged) {
+        if (hasChanged) {
             final Window w = getWindow();
-            final Event event = new HashChangeEvent(w, Event.TYPE_HASH_CHANGE, oldURL, getHref());
-            w.executeEventLocally(event);
+            final Page page = w.getWebWindow().getEnclosedPage();
+            if (page != null) {
+                final WebRequest request = page.getWebResponse().getWebRequest();
+                request.setUrl(UrlUtils.toUrlSafe(getHref()));
+            }
+
+            if (triggerHashChanged) {
+                final Event event = new HashChangeEvent(w, Event.TYPE_HASH_CHANGE, oldURL, getHref());
+                w.executeEventLocally(event);
+            }
         }
     }
 

--- a/src/test/java/org/htmlunit/javascript/host/LocationTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/LocationTest.java
@@ -406,6 +406,23 @@ public class LocationTest extends SimpleWebTestCase {
     }
 
     /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void setHashAboutBlank() throws Exception {
+        try (WebClient webClient = new WebClient()) {
+            HtmlPage page = webClient.getPage("about:blank");
+            assertNull(page.getUrl().getRef());
+
+            page.executeJavaScript("location.hash = 'foo'");
+            assertEquals("foo", page.getUrl().getRef());
+
+            page = (HtmlPage) page.refresh();
+            assertEquals("foo", page.getUrl().getRef());
+        }
+    }
+
+    /**
      * @throws Exception if an error occurs
      */
     @Test

--- a/src/test/java/org/htmlunit/javascript/host/LocationTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/LocationTest.java
@@ -295,7 +295,7 @@ public class LocationTest extends SimpleWebTestCase {
 
         // Verify that we didn't reload the page.
         assertTrue(page == page2);
-        assertEquals(URL_FIRST, conn.getLastWebRequest().getUrl());
+        assertEquals(1, conn.getRequestCount());
     }
 
     /**
@@ -380,6 +380,29 @@ public class LocationTest extends SimpleWebTestCase {
         final HtmlPage c = (HtmlPage) a.getFrameByName("c").getEnclosedPage();
         c.getHtmlElementById("anchor").click();
         assertEquals(getExpectedAlerts(), alerts);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void setHashUpdatesPageUrl() throws Exception {
+        final WebClient webClient = getWebClient();
+        final MockWebConnection conn = new MockWebConnection();
+
+        final String html = DOCTYPE_HTML
+            + "<html><head><title>Test</title></head><body>\n"
+            + "<a id='a' onclick='location.hash=\"newHash\"'>go</a>\n"
+            + "</body></html>";
+
+        conn.setResponse(URL_FIRST, html);
+        webClient.setWebConnection(conn);
+
+        final HtmlPage page = webClient.getPage(URL_FIRST);
+        assertNull(page.getUrl().getRef());
+
+        page.getHtmlElementById("a").click();
+        assertEquals("newHash", page.getUrl().getRef());
     }
 
     /**


### PR DESCRIPTION
### This PR does the following

- Fix `Location.setHash()` to update the page's `WebRequest` URL when the hash changes, ensuring `page.getUrl()` reflects the current hash

- Fix `WebClient.makeWebResponseForAboutUrl()` to properly handle `about:blank` with hash fragments (e.g., `about:blank#foo`) instead of throwing `MalformedURLException`
