### PR TITLE
Make FunctionWrapper implement SymbolScriptable

### DIFF
--- a/src/main/java/org/htmlunit/javascript/FunctionWrapper.java
+++ b/src/main/java/org/htmlunit/javascript/FunctionWrapper.java
@@ -19,6 +19,8 @@ import java.io.Serializable;
 import org.htmlunit.corejs.javascript.Context;
 import org.htmlunit.corejs.javascript.Function;
 import org.htmlunit.corejs.javascript.Scriptable;
+import org.htmlunit.corejs.javascript.Symbol;
+import org.htmlunit.corejs.javascript.SymbolScriptable;
 
 /**
  * Wrapper for a {@link Function} delegating all calls to the wrapped instance.
@@ -26,8 +28,9 @@ import org.htmlunit.corejs.javascript.Scriptable;
  * @author Marc Guillemot
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
-public class FunctionWrapper implements Function, Serializable {
+public class FunctionWrapper implements Function, SymbolScriptable, Serializable {
     private final Function wrapped_;
 
     /**
@@ -82,6 +85,14 @@ public class FunctionWrapper implements Function, Serializable {
      * {@inheritDoc}
      */
     @Override
+    public Object get(final Symbol key, final Scriptable start) {
+        return ((SymbolScriptable) wrapped_).get(key, start);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean has(final String name, final Scriptable start) {
         return wrapped_.has(name, start);
     }
@@ -92,6 +103,14 @@ public class FunctionWrapper implements Function, Serializable {
     @Override
     public boolean has(final int index, final Scriptable start) {
         return wrapped_.has(index, start);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean has(final Symbol key, final Scriptable start) {
+        return ((SymbolScriptable) wrapped_).has(key, start);
     }
 
     /**
@@ -114,6 +133,14 @@ public class FunctionWrapper implements Function, Serializable {
      * {@inheritDoc}
      */
     @Override
+    public void put(final Symbol key, final Scriptable start, final Object value) {
+        ((SymbolScriptable) wrapped_).put(key, wrapped_, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void delete(final String name) {
         wrapped_.delete(name);
     }
@@ -124,6 +151,14 @@ public class FunctionWrapper implements Function, Serializable {
     @Override
     public void delete(final int index) {
         wrapped_.delete(index);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void delete(final Symbol key) {
+        ((SymbolScriptable) wrapped_).delete(key);
     }
 
     /**

--- a/src/test/java/org/htmlunit/javascript/FunctionsWrapperTest.java
+++ b/src/test/java/org/htmlunit/javascript/FunctionsWrapperTest.java
@@ -46,4 +46,119 @@ public class FunctionsWrapperTest extends WebDriverTestCase {
 
         loadPageVerifyTitle2(html);
     }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts("true")
+    public void symbolHasInstance() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "function test() {\n"
+            + "  log(Function.prototype.toString instanceof Function);\n"
+            + "}\n"
+            + "</script></head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"[object Function]", "[object Function]", "[object Function]"})
+    public void symbolToStringTag() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "function test() {\n"
+            + "  var toString = Object.prototype.toString;\n"
+            + "  log(toString.call(Function.prototype.toString));\n"
+            + "  log(toString.call(Object.prototype.toString));\n"
+            + "  log(toString.call(Array.prototype.toString));\n"
+            + "}\n"
+            + "</script></head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"undefined", "undefined", "false", "false"})
+    public void symbolPropertyAccess() throws Exception {
+        final String html = DOCTYPE_HTML
+                + "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "function test() {\n"
+                + "  var fn = Function.prototype.toString;\n"
+                + "  log(fn[Symbol.toStringTag]);\n"
+                + "  log(fn[Symbol.toPrimitive]);\n"
+                + "  log(Symbol.toStringTag in fn);\n"
+                + "  log(Symbol.toPrimitive in fn);\n"
+                + "}\n"
+                + "</script></head><body onload='test()'>\n"
+                + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"undefined", "hello", "true"})
+    public void symbolPropertyWriteRead() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "function test() {\n"
+            + "  var fn = Function.prototype.toString;\n"
+            + "  var sym = Symbol('test');\n"
+            + "  log(fn[sym]);\n"
+            + "  fn[sym] = 'hello';\n"
+            + "  log(fn[sym]);\n"
+            + "  log(sym in fn);\n"
+            + "}\n"
+            + "</script></head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts({"hello", "true", "undefined", "false"})
+    public void symbolPropertyDelete() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><head>\n"
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "function test() {\n"
+            + "  var fn = Function.prototype.toString;\n"
+            + "  var sym = Symbol('del');\n"
+            + "  fn[sym] = 'hello';\n"
+            + "  log(fn[sym]);\n"
+            + "  log(sym in fn);\n"
+            + "  delete fn[sym];\n"
+            + "  log(fn[sym]);\n"
+            + "  log(sym in fn);\n"
+            + "}\n"
+            + "</script></head><body onload='test()'>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
 }


### PR DESCRIPTION
### This PR does the following

Make `FunctionWrapper` implement `SymbolScriptable` interface, delegating `Symbol` operations to the wrapped function.

### Problem
`Object.prototype.toString.call()` on a `FunctionWrapper` triggers a `Symbol.toStringTag` lookup via `ScriptRuntime.defaultObjectToString()`. Since `FunctionWrapper` did not implement `SymbolScriptable`, this threw "TypeError: Object function does not support Symbol keys".