### PR TITLE
Fix maven-model and maven-artifact missing test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1613,11 +1613,13 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
             <version>${maven-model.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>${maven-artifact.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Jetty -->


### PR DESCRIPTION
Fixes #1124

`maven-model` and `maven-artifact` are only used in `ExternalTest.java` but were declared without `<scope>test</scope>`, causing them (and `plexus-utils` transitively) to leak into the compile scope of downstream projects.

This adds the missing `<scope>test</scope>` to both dependencies.