### PR TITLE
Fix document.cookie ordering

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/dom/Document.java
+++ b/src/main/java/org/htmlunit/javascript/host/dom/Document.java
@@ -28,9 +28,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -1133,10 +1135,23 @@ public class Document extends Node {
 
         final StringBuilder builder = new StringBuilder();
         final Set<Cookie> cookies = sgmlPage.getWebClient().getCookies(sgmlPage.getUrl());
+        final List<Cookie> visibleCookies = new ArrayList<>();
         for (final Cookie cookie : cookies) {
             if (cookie.isHttpOnly()) {
                 continue;
             }
+            visibleCookies.add(cookie);
+        }
+
+        visibleCookies.sort((a, b) -> {
+            final String pathA = a.getPath();
+            final String pathB = b.getPath();
+            final int lenA = pathA == null ? 0 : pathA.length();
+            final int lenB = pathB == null ? 0 : pathB.length();
+            return Integer.compare(lenB, lenA);
+        });
+
+        for (final Cookie cookie : visibleCookies) {
             if (builder.length() != 0) {
                 builder.append("; ");
             }

--- a/src/test/java/org/htmlunit/CookieManagerTest.java
+++ b/src/test/java/org/htmlunit/CookieManagerTest.java
@@ -94,25 +94,50 @@ public class CookieManagerTest extends WebDriverTestCase {
      * @throws Exception if the test fails
      */
     @Test
+    @Alerts({"b=2; a=1",
+             "c=1; d=2",
+             "lA=2; lB=3; sA=1; sB=4"})
     public void orderCookiesByPath_fromJs() throws Exception {
         final String html = DOCTYPE_HTML
-            + "<html><body><script>\n"
-            + "document.cookie = 'exampleCookie=rootPath;path=/';\n"
-            + "document.cookie = 'exampleCookie=currentPath;path=/testpages/';\n"
-            + "</script>\n"
+            + "<html><head><script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  function clear(n, p) {\n"
+            + "    document.cookie = n + '=; path=' + p + '; max-age=0';\n"
+            + "  }\n"
+            + "  function test() {\n"
+            + "    document.cookie = 'a=1; path=/';\n"
+            + "    document.cookie = 'b=2; path=/testpages';\n"
+            + "    log(document.cookie);\n"
+            + "    clear('a', '/'); clear('b', '/testpages');\n"
+            + "    document.cookie = 'c=1; path=/testpages';\n"
+            + "    document.cookie = 'd=2; path=/testpages';\n"
+            + "    log(document.cookie);\n"
+            + "    clear('c', '/testpages'); clear('d', '/testpages');\n"
+            + "    document.cookie = 'sA=1; path=/';\n"
+            + "    document.cookie = 'lA=2; path=/testpages';\n"
+            + "    document.cookie = 'lB=3; path=/testpages';\n"
+            + "    document.cookie = 'sB=4; path=/';\n"
+            + "    log(document.cookie);\n"
+            + "  }\n"
+            + "</script></head>\n"
+            + "<body onload='test()'>\n"
             + "<a href='/testpages/next.html'>next page</a>\n"
             + "</body></html>";
 
+        final URL pageUrl = new URL(URL_FIRST, "testpages/test.html");
+        getMockWebConnection().setResponse(pageUrl, html);
         getMockWebConnection().setDefaultResponse("");
 
         final WebDriver webDriver = getWebDriver();
         webDriver.manage().deleteAllCookies();
 
-        loadPage2(html);
+        loadPage2(pageUrl, StandardCharsets.ISO_8859_1);
+        verifyTitle2(getWebDriver(), getExpectedAlerts());
+
         webDriver.findElement(By.linkText("next page")).click();
 
         final WebRequest lastRequest = getMockWebConnection().getLastWebRequest();
-        assertEquals("exampleCookie=currentPath; exampleCookie=rootPath",
+        assertEquals("lA=2; lB=3; sA=1; sB=4",
             lastRequest.getAdditionalHeaders().get(HttpHeader.COOKIE));
     }
 


### PR DESCRIPTION
### This PR does the following

Fix `Document.getCookie()` to serialize cookies in the order required by [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.4) section 2: cookies with longer paths first, then by creation time.