### PR TITLE
security: restrict external resource access in XSLTProcessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1417,6 +1417,10 @@
         <contributor>
             <name>Sebastian Peters</name>
         </contributor>
+        <contributor>
+            <name>MatrixNeoKozak</name>
+            <email>matrixneo2026@tutamail.com</email>
+        </contributor>
     </contributors>
     <dependencies>
         <!-- this includes httpclient as dependency -->

--- a/src/main/java/org/htmlunit/javascript/host/xml/XSLTProcessor.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/XSLTProcessor.java
@@ -58,6 +58,7 @@ import org.w3c.dom.NodeList;
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author MatrixNeoKozak
  */
 @JsxClass
 public class XSLTProcessor extends HtmlUnitScriptable {

--- a/src/main/java/org/htmlunit/javascript/host/xml/XSLTProcessor.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/XSLTProcessor.java
@@ -129,6 +129,18 @@ public class XSLTProcessor extends HtmlUnitScriptable {
             // which sets a number of processing limits on the processors. Conversely, by default,
             // the JDK turns off FSP for transformers and XPath, which enables extension functions for XSLT and XPath.
             transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            try {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            }
+            catch (final IllegalArgumentException ignored) {
+                // ignore
+            }
+            try {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            }
+            catch (final IllegalArgumentException ignored) {
+                // ignore
+            }
 
             final SgmlPage page = sourceDomNode.getPage();
             if (page != null && page.getWebClient().getBrowserVersion()
@@ -191,6 +203,12 @@ public class XSLTProcessor extends HtmlUnitScriptable {
             }
 
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            try {
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            }
+            catch (final javax.xml.parsers.ParserConfigurationException ignored) {
+                // ignore
+            }
             final org.w3c.dom.Document containerDocument = factory.newDocumentBuilder().newDocument();
             final org.w3c.dom.Element containerElement = containerDocument.createElement("container");
             containerDocument.appendChild(containerElement);


### PR DESCRIPTION
Configure TransformerFactory and DocumentBuilderFactory in XSLTProcessor with FEATURE_SECURE_PROCESSING and restrict external DTD and stylesheet references to mitigate remote resource loading during XSLT transformation.