### PR TITLE
Remove obsolete JavadocStyle check

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -140,12 +140,6 @@
         <module name="JavadocVariable">
             <property name="accessModifiers" value="protected"/>
         </module>
-        <module name="JavadocStyle">
-            <property name="scope" value="protected"/>
-            <property name="checkFirstSentence" value="true"/>
-            <property name="checkEmptyJavadoc" value="false"/>
-            <property name="checkHtml" value="true"/>
-        </module>
         <module name="InvalidJavadocPosition"/>
         <module name="JavadocContentLocation"/>
         <module name="JavadocLeadingAsteriskAlign" />


### PR DESCRIPTION
Removes the obsolete `JavadocStyle` check because it is being removed from Checkstyle in [checkstyle/checkstyle#20582](https://github.com/checkstyle/checkstyle/pull/20582).

If this project wants to keep validating Javadoc summaries, `SummaryJavadoc` is the more reliable replacement because it specifically validates summary text. I did not add it here because it currently introduces 674 violations, so that migration should be handled separately.