### PR TITLE
HTMLEmbedElement: add getter and setter for src and type

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLEmbedElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLEmbedElement.java
@@ -14,8 +14,14 @@
  */
 package org.htmlunit.javascript.host.html;
 
+import static org.htmlunit.html.DomElement.ATTRIBUTE_NOT_DEFINED;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.htmlunit.html.DomElement;
 import org.htmlunit.html.HtmlEmbed;
+import org.htmlunit.html.HtmlPage;
 import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
 import org.htmlunit.javascript.configuration.JsxGetter;
@@ -93,6 +99,54 @@ public class HTMLEmbedElement extends HTMLElement {
     @JsxSetter(propertyName = "width")
     public void setWidth_js(final String width) {
         getDomNodeOrDie().setAttribute("width", width);
+    }
+
+    /**
+     * Returns the value of the {@code src} property.
+     * @return the value of the {@code src} property
+     */
+    @JsxGetter
+    public String getSrc() {
+        final HtmlEmbed embed = (HtmlEmbed) getDomNodeOrDie();
+        String src = embed.getAttributeDirect("src");
+        if (ATTRIBUTE_NOT_DEFINED == src) {
+            return src;
+        }
+        try {
+            final URL expandedSrc = ((HtmlPage) embed.getPage()).getFullyQualifiedUrl(src);
+            src = expandedSrc.toString();
+        }
+        catch (final MalformedURLException ignored) {
+            // ignore
+        }
+        return src;
+    }
+
+    /**
+     * Sets the value of the {@code src} property.
+     * @param src the value of the {@code src} property
+     */
+    @JsxSetter
+    public void setSrc(final String src) {
+        getDomNodeOrDie().setAttribute("src", src);
+    }
+
+    /**
+     * Returns the value of the {@code type} property.
+     * @return the value of the {@code type} property
+     */
+    @JsxGetter
+    public String getType() {
+        return getDomNodeOrDie().getAttributeDirect("type");
+    }
+
+    /**
+     * Sets the value of the {@code type} property.
+     * @param type the value of the {@code type} property
+     */
+    @JsxSetter
+    public void setType(final String type) {
+        getDomNodeOrDie().setAttribute("type", type);
     }
 
     /**

--- a/src/test/java/org/htmlunit/general/ElementOwnPropertiesTest.java
+++ b/src/test/java/org/htmlunit/general/ElementOwnPropertiesTest.java
@@ -5266,10 +5266,10 @@ public class ElementOwnPropertiesTest extends WebDriverTestCase {
                 + "width[GSCE]",
             FF_ESR = "align[GSCE],constructor(),getSVGDocument(),height[GSCE],name[GSCE],src[GSCE],type[GSCE],"
                 + "width[GSCE]")
-    @HtmlUnitNYI(CHROME = "align[GSCE],constructor(),height[GSCE],name[GSCE],width[GSCE]",
-            EDGE = "align[GSCE],constructor(),height[GSCE],name[GSCE],width[GSCE]",
-            FF_ESR = "align[GSCE],constructor(),height[GSCE],name[GSCE],width[GSCE]",
-            FF = "align[GSCE],constructor(),height[GSCE],name[GSCE],width[GSCE]")
+    @HtmlUnitNYI(CHROME = "align[GSCE],constructor(),height[GSCE],name[GSCE],src[GSCE],type[GSCE],width[GSCE]",
+            EDGE = "align[GSCE],constructor(),height[GSCE],name[GSCE],src[GSCE],type[GSCE],width[GSCE]",
+            FF_ESR = "align[GSCE],constructor(),height[GSCE],name[GSCE],src[GSCE],type[GSCE],width[GSCE]",
+            FF = "align[GSCE],constructor(),height[GSCE],name[GSCE],src[GSCE],type[GSCE],width[GSCE]")
     public void embed() throws Exception {
         test("embed");
     }

--- a/src/test/java/org/htmlunit/general/ElementPropertiesTest.java
+++ b/src/test/java/org/htmlunit/general/ElementPropertiesTest.java
@@ -1837,10 +1837,10 @@ public class ElementPropertiesTest extends WebDriverTestCase {
      */
     @Test
     @Alerts("align,getSVGDocument(),height,name,src,type,width")
-    @HtmlUnitNYI(CHROME = "align,height,name,width",
-            EDGE = "align,height,name,width",
-            FF_ESR = "align,height,name,width",
-            FF = "align,height,name,width")
+    @HtmlUnitNYI(CHROME = "align,height,name,src,type,width",
+            EDGE = "align,height,name,src,type,width",
+            FF_ESR = "align,height,name,src,type,width",
+            FF = "align,height,name,src,type,width")
     public void embed() throws Exception {
         test("embed");
     }

--- a/src/test/java/org/htmlunit/javascript/host/html/HTMLEmbedElementTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/html/HTMLEmbedElementTest.java
@@ -221,4 +221,94 @@ public class HTMLEmbedElementTest extends WebDriverTestCase {
 
         loadPageVerifyTitle2(html);
     }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"§§URL§§foo.pdf", ""})
+    public void getSrc() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><body>\n"
+            + "  <embed id='e1' src='foo.pdf' ></embed>\n"
+            + "  <embed id='e2' ></embed>\n"
+
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  for (var i = 1; i <= 2; i++) {\n"
+            + "    log(document.getElementById('e' + i).src);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"§§URL§§foo.pdf", "§§URL§§bar.pdf"})
+    public void setSrc() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><body>\n"
+            + "  <embed id='e1' src='foo.pdf' ></embed>\n"
+
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  var elem = document.getElementById('e1');\n"
+            + "  log(elem.src);\n"
+            + "  elem.src = 'bar.pdf';\n"
+            + "  log(elem.src);\n"
+            + "</script>\n"
+            + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"application/pdf", ""})
+    public void getType() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><body>\n"
+            + "  <embed id='e1' type='application/pdf' ></embed>\n"
+            + "  <embed id='e2' ></embed>\n"
+
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  for (var i = 1; i <= 2; i++) {\n"
+            + "    log(document.getElementById('e' + i).type);\n"
+            + "  }\n"
+            + "</script>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @Alerts({"application/pdf", "text/plain"})
+    public void setType() throws Exception {
+        final String html = DOCTYPE_HTML
+            + "<html><body>\n"
+            + "  <embed id='e1' type='application/pdf' ></embed>\n"
+
+            + "<script>\n"
+            + LOG_TITLE_FUNCTION
+            + "  var elem = document.getElementById('e1');\n"
+            + "  log(elem.type);\n"
+            + "  elem.type = 'text/plain';\n"
+            + "  log(elem.type);\n"
+            + "</script>\n"
+            + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
 }


### PR DESCRIPTION
## This PR does the following

Add missing getter / setter for `src` and `type` property of `HTMLEmbedElement`